### PR TITLE
fix: neon delete-branch-action deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,4 +114,4 @@ jobs:
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          branch_id: ${{ needs.neon-branch.outputs.branch_id }}
+          branch: ${{ needs.neon-branch.outputs.branch_id }}


### PR DESCRIPTION
One-liner: `branch_id` → `branch` in `neondatabase/delete-branch-action@v3`.

Fixes the CI annotation:
> Input 'branch_id' has been deprecated with message: The `branch_id` input is deprecated in favor of `branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)