### PR TITLE
docs: CI/CD pipeline documentation + /setup-ci skill

### DIFF
--- a/docs/ci-cd-pipeline.md
+++ b/docs/ci-cd-pipeline.md
@@ -1,0 +1,551 @@
+# Pipeline CI/CD
+
+## Przegląd
+
+Dokument opisuje istniejacy, w pelni dzialajacy pipeline CI/CD dla monorepo `powiadomienia.info`. Kazda zmiana kodu przechodzi przez zautomatyzowane testy i bramki jakosci przed dotarciem do srodowiska stagingowego lub produkcyjnego.
+
+```
+PR otwarty
+    |
+    v
+[neon-branch] Tworzy efemerycza galaz Neon Postgres (ci/pr-{nr})
+    |
+    v
+[ci] Lint (Biome) + Testy (Neon managed) + Bramki doradcze
+    |
+[cleanup-neon-branch] Usuwa galaz Neon (zawsze, nawet przy bledzie)
+    |
+    v
+PR zmergowany do main
+    |
+    v
+[deploy-stage] Automatyczny deploy na stage (data-service + user-application)
+    |
+    v
+Deploy na prod (reczny, wymaga zatwierdzenia przez reviewer)
+```
+
+---
+
+## 1. Struktura repozytorium
+
+```
+.github/
+└── workflows/
+    ├── ci.yml             # Bramka jakosci: PR + push do main
+    ├── deploy-stage.yml   # Auto-deploy na staging po merge
+    └── deploy-prod.yml    # Reczny deploy na produkcje z zatwierdzeniem
+packages/
+└── test-harness/
+    └── src/
+        └── db.ts          # Fabryka testowej bazy danych (dual-profile)
+```
+
+---
+
+## 2. GitHub Actions — workflow CI (`ci.yml`)
+
+**Plik:** `.github/workflows/ci.yml`
+
+**Wyzwalacze:**
+- `pull_request` do brancha `main`
+- `push` do brancha `main`
+
+**Wspolbieznosc:** `ci-${{ github.ref }}`, nowe uruchomienie anuluje poprzednie na tym samym ref.
+
+### Job: `neon-branch` (tylko PR)
+
+Tworzy efemerycza galaz Neon Postgres dla kazdego PR, tak aby testy dzialaly na prawdziwym Postgresie zamiast na emulacji.
+
+```
+Akcja: neondatabase/create-branch-action@v6
+Nazwa galezi: ci/pr-{numer_pr}
+Czas zycia: od otwarcia PR do zamkniecia/merge (patrz: cleanup-neon-branch)
+```
+
+Wyjscia joba ustawiane jako zmienne srodowiskowe dla joba `ci`:
+- `db_url` — connection string z pooler (przekazywany jako `TEST_DATABASE_URL`)
+- `branch_id` — identyfikator galezi Neon (uzywany przy sprzataniu)
+
+Zmienne wymagane przez akcje:
+- `vars.NEON_PROJECT_ID` — GitHub Variable, wstrzykiwana automatycznie przez integracjê Neon
+- `secrets.NEON_API_KEY` — GitHub Secret, wstrzykiwany automatycznie przez integracjê Neon
+
+### Job: `ci` (zawsze, nawet gdy `neon-branch` pominieto)
+
+`if: always()` — job uruchamia sie niezaleznie od tego, czy job `neon-branch` zostal pominiety (push do main nie tworzy galezi Neon).
+
+**Kroki:**
+
+1. Checkout (`actions/checkout@v4`, `fetch-depth: 1`, bez utrwalania credentials)
+2. Setup pnpm (`pnpm/action-setup@v4`)
+3. Setup Node.js LTS (`actions/setup-node@v4`, cache pnpm)
+4. `pnpm install --frozen-lockfile`
+5. `pnpm run build:data-ops` — kompilacja pakietu wspoldzielonego (wymagane przed testami)
+
+**Twarde bramki (blokuja merge):**
+
+| Krok | Polecenie | Co sprawdza |
+|------|-----------|-------------|
+| Lint (Biome) | `pnpm run lint:ci` | Formatowanie i linting calego kodu objetego Biome |
+| Testy | `pnpm run test` | Vitest — pelna suita testow |
+
+Srodowisko dla krokow testow jest wstrzykiwane dynamicznie:
+
+```yaml
+env:
+  TEST_DATABASE_URL: ${{ needs.neon-branch.outputs.db_url }}
+  TEST_DB_PROFILE: ${{ needs.neon-branch.outputs.db_url && 'managed' || 'local' }}
+```
+
+Oznacza to:
+- **Na PR:** `TEST_DB_PROFILE=managed`, `TEST_DATABASE_URL` = URL efeme­rycznej galezi Neon — testy dzialaja na prawdziwym Postgresie.
+- **Na push do main:** `TEST_DB_PROFILE=local`, `TEST_DATABASE_URL` = pusty — testy uzyja PGLite w pamieci.
+
+**Bramki doradcze (continue-on-error: true — nie blokuja merge):**
+
+| Krok | Polecenie | Co sprawdza |
+|------|-----------|-------------|
+| Typecheck (advisory) | `pnpm run types` | TypeScript w `data-service` + `user-application` |
+| Dead code (advisory) | `pnpm run knip` | Martwy kod i nieuzywane zaleznosci (Knip) |
+| Dep freshness (advisory) | `pnpm run deps` | Przestarzale zaleznosci (Taze) |
+
+Bramki doradcze sa doradcze dlatego, ze przed startem M1 istnieje juz dug techniczny w `apps/` i `packages/data-ops`. Beda przeniesione do twardych bramek gdy dug zostanie sprzatniêty (faza 3+).
+
+### Job: `cleanup-neon-branch` (tylko PR)
+
+Usuwa efemerycza galaz Neon po zakonczeniu CI, nawet gdy `ci` sie nie powiedlo:
+
+```yaml
+if: always() && needs.neon-branch.outputs.branch_id
+uses: neondatabase/delete-branch-action@v3
+```
+
+Dzieki temu nie pozostaja osierocone galêzie Neon, ktore moglyby generowac koszty.
+
+---
+
+## 3. GitHub Actions — workflow deploy-stage (`deploy-stage.yml`)
+
+**Plik:** `.github/workflows/deploy-stage.yml`
+
+**Wyzwalacze:**
+- `push` do brancha `main` (po przejsciu CI)
+- `workflow_dispatch` (reczne uruchomienie)
+
+**Wspolbieznosc:** `deploy-stage`, `cancel-in-progress: false` — deploye na stage nie anuluja siebie wzajemnie.
+
+**Srodowisko GitHub:** `stage` (otwarte, bez wymaganego zatwierdzenia)
+
+**URL docelowy:** `https://stage.powiadomienia.info`
+
+**Kroki:**
+
+1. Checkout (`fetch-depth: 1`)
+2. Setup pnpm + Node.js LTS
+3. `pnpm install --frozen-lockfile`
+4. `pnpm run build:data-ops`
+5. `pnpm run deploy:stage:data-service` — deploy workera Hono
+6. `pnpm run deploy:stage:user-application` — deploy frontendu TanStack Start
+
+Kazdy krok deploy uzywa:
+```yaml
+env:
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+Kazde polecenie deploy w `package.json` najpierw buduje `data-ops` a potem wywoluje `wrangler deploy --env stage` dla danej aplikacji.
+
+---
+
+## 4. GitHub Actions — workflow deploy-prod (`deploy-prod.yml`)
+
+**Plik:** `.github/workflows/deploy-prod.yml`
+
+**Wyzwalacze:**
+- **Wylacznie** `workflow_dispatch` — ktos musi rêcznie kliknac "Run workflow" w zakladce Actions
+
+**Wejscie:**
+```yaml
+inputs:
+  ref:
+    description: "Git ref to deploy (defaults to main)"
+    required: false
+    default: main
+```
+
+Mozliwosc podania `ref` pozwala deployowac konkretny commit lub tag, jesli zachodzi potrzeba cofniecia zmian.
+
+**Wspolbieznosc:** `deploy-prod`, `cancel-in-progress: false`
+
+**Srodowisko GitHub:** `production` — wymagany recenzent (tkowalczyk) zanim job zostanie uruchomiony.
+
+**URL docelowy:** `https://powiadomienia.info`
+
+**Kroki:** identyczne jak `deploy-stage`, ale z `--env prod`.
+
+**Limit czasowy:** 20 minut (stage: 15 minut) — wigla na wypadek wolniejszej sieci CDN Cloudflare dla produkcji.
+
+---
+
+## 5. Diagramy przeplywow
+
+### PR flow (pelny)
+
+```
+git push origin feature/xxx
+        |
+        v
+    GitHub PR otwarty
+        |
+   +-----------+----------+
+   |                      |
+   v                      |
+[neon-branch]             |
+Tworzy ci/pr-{N}          |
+w Neon Postgres           |
+   |                      |
+   v                      v
+[ci] (needs: neon-branch, if: always())
+  1. checkout
+  2. pnpm install
+  3. build data-ops
+  4. biome ci .           <- blokuje merge jesli nie przejdzie
+  5. vitest run           <- blokuje merge jesli nie przejdzie
+     TEST_DB_PROFILE=managed
+     TEST_DATABASE_URL=<neon-branch-url>
+  6. pnpm types           <- doradcze, nie blokuje
+  7. pnpm knip            <- doradcze, nie blokuje
+  8. pnpm deps            <- doradcze, nie blokuje
+        |
+        v
+[cleanup-neon-branch] (if: always() && branch_id istnieje)
+Usuwa ci/pr-{N} z Neon
+        |
+        v
+   Status check "Lint + Test + Quality" wymagany przez branch protection
+```
+
+### Push do main (po merge)
+
+```
+PR zmergowany do main
+        |
+   +----+----+
+   |         |
+   v         v
+  [ci]    [deploy-stage] (rownolegle)
+  (push)  
+  TEST_DB_PROFILE=local
+  (PGLite, bez Neon)
+             |
+             v
+     deploy:stage:data-service
+     deploy:stage:user-application
+             |
+             v
+     https://stage.powiadomienia.info
+```
+
+### Deploy produkcyjny
+
+```
+Developer otwiera GitHub Actions
+        |
+        v
+"Run workflow" na deploy-prod.yml
+Opcjonalnie: podaje ref (commit/tag)
+        |
+        v
+GitHub czeka na zatwierdzenie przez tkowalczyk
+        |
+        v
+Zatwierdzenie -> job startuje
+        |
+        v
+checkout (konkretny ref)
+pnpm install
+build data-ops
+deploy:prod:data-service
+deploy:prod:user-application
+        |
+        v
+https://powiadomienia.info
+```
+
+---
+
+## 6. Test-harness — dual-profile (`packages/test-harness/src/db.ts`)
+
+Pakiet `test-harness` dostarcza funkcje `createTestDb()` ktora zwraca uchwyt do bazy danych dla testow. Implementacja wspiera dwa profile wybierane przez zmiennik srodowiskowy `TEST_DB_PROFILE`.
+
+### Profile: `local` (domyslny)
+
+```
+TEST_DB_PROFILE=local  (lub nie ustawiony)
+
+PGLite (in-memory, @electric-sql/pglite)
+  |
+  v
+drizzle-orm/pglite
+  |
+  v
+Migracje z packages/data-ops/src/drizzle/migrations/dev/
+  |
+  v
+Swiezy schemat gotowy do uzycia w tescie
+```
+
+- Kazde wywolanie `createTestDb()` zwraca izolowana baze w pamieci.
+- Brak dostêpu do sieci, maksymalna szybkosc.
+- Cleanup: `pg.close()` (bezpieczne do wielokrotnego wywolania).
+
+### Profile: `managed`
+
+```
+TEST_DB_PROFILE=managed + TEST_DATABASE_URL=<postgres-url>
+
+@neondatabase/serverless (HTTP, neon())
+  |
+  v
+drizzle-orm/neon-http
+  |
+  v
+Migracje z packages/data-ops/src/drizzle/migrations/dev/
+  |
+  v
+Prawdziwy schemat Postgres gotowy do uzycia w tescie
+```
+
+- Lacze sie z rzeczywistym Neon Postgres wskazanym przez `TEST_DATABASE_URL`.
+- W CI: URL efeme­rycznej galezi PR przekazywany przez job `neon-branch`.
+- Lokalnie: developer moze wskazac wlasna galaz Neon.
+- Polaczenie HTTP (bez pool) — kazde zapytanie to osobny fetch, nic do czyszczenia.
+- Cleanup: no-op (brak polaczenia TCP do zamkniecia).
+
+### Wspolny interfejs
+
+```typescript
+export interface TestDbHandle {
+  db: PgDatabase<any, any, any>;
+  cleanup: () => Promise<void>;
+}
+
+export async function createTestDb(): Promise<TestDbHandle>
+```
+
+Oba profile zwracaja ten sam interfejs `TestDbHandle`, wiec testy nie muszą wiedziec z jakiego profilu korzystaja.
+
+### Zrodel migracji
+
+Obie profile stosuja migracje ze sciezki:
+
+```
+packages/data-ops/src/drizzle/migrations/dev/
+```
+
+Sciezka jest rozwiazywana wzgledem lokalizacji pliku `db.ts` (nie CWD), wiec dziala stabilnie z kazdego katalogu:
+
+```typescript
+const MIGRATIONS_FOLDER = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../data-ops/src/drizzle/migrations/dev",
+);
+```
+
+### Seam do wstrzykiwania bazy w testach
+
+`packages/data-ops/src/database/setup.ts` udostepnia seam do wstrzykiwania testowej bazy:
+
+```typescript
+// Sciezka produkcyjna (host/user/password)
+initDatabase({ host, username, password });
+
+// Sciezka testowa (gotowy uchwyt Drizzle)
+initDatabase({ client: handle.db });
+
+// Miedzy testami — czysci slot modulu
+resetDatabase();
+```
+
+Wszystkie zapytania w `data-ops/src/queries/` uzywaja `getDb()` ktory czyta z tego slotu. Dzieki temu test moze podmieniac baze bez modyfikowania kodu zapytan.
+
+---
+
+## 7. Stos bramek jakosci
+
+| Narzedzie | Wersja | Polecenie | Przeznaczenie | Status w CI |
+|-----------|--------|-----------|---------------|-------------|
+| Biome | 2.4.4 | `pnpm lint:ci` | Lint + formatowanie | **Twarda bramka** |
+| Vitest | ^4.0.15 | `pnpm test` | Testy jednostkowe i integracyjne | **Twarda bramka** |
+| tsc | ^5.9.3 | `pnpm types` | Sprawdzanie typow TypeScript | Doradcza |
+| Knip | ^5.88.1 | `pnpm knip` | Martwy kod i nieuzywane zaleznosci | Doradcza |
+| Taze | ^19.11.0 | `pnpm deps` | Przestarzale zaleznosci | Doradcza |
+
+### Zakres Biome
+
+Biome jest skonfigurowany w `biome.json` z wylaczonym zakresem dla starszego kodu:
+
+```json
+"files": {
+  "includes": [
+    "**",
+    "!apps",
+    "!packages/data-ops",
+    ...
+  ]
+}
+```
+
+Innymi slowy: Biome sprawdza `packages/test-harness` i inne nowe pakiety, ale pomija `apps/` i `packages/data-ops` do czasu gdy legacy code zostanie posprzatane.
+
+### Polecenie `pnpm types`
+
+```bash
+pnpm run build:data-ops && pnpm run --filter data-service --filter user-application --if-present types
+```
+
+Najpierw przebudowuje `data-ops` (zrodlo prawdy dla typow), a nastepnie uruchamia `tsc` dla obu aplikacji.
+
+---
+
+## 8. Sekrety i srodowiska
+
+### Zmienne GitHub
+
+| Nazwa | Typ | Jak ustawiono | Uzywane w |
+|-------|-----|---------------|-----------|
+| `NEON_API_KEY` | Secret | Automatycznie przez integracjê Neon | `ci.yml` (neon-branch, cleanup) |
+| `NEON_PROJECT_ID` | Variable | Automatycznie przez integracjê Neon | `ci.yml` (neon-branch, cleanup) |
+| `CLOUDFLARE_API_TOKEN` | Secret | Rêcznie (Workers Edit, Account scope) | `deploy-stage.yml`, `deploy-prod.yml` |
+| `CLOUDFLARE_ACCOUNT_ID` | Secret | Rêcznie | `deploy-stage.yml`, `deploy-prod.yml` |
+
+### Sekrety aplikacji
+
+Sekrety aplikacyjne (polaczenia z bazà, dane logowania SerwerSMS itp.) **nie sa** przechowywane w GitHub. Zarzadzane sa bezposrednio w Cloudflare Workers per-srodowisko:
+
+```bash
+wrangler secret put DATABASE_HOST --env stage
+wrangler secret put DATABASE_USERNAME --env stage
+wrangler secret put DATABASE_PASSWORD --env stage
+wrangler secret put SERWERSMS_USERNAME --env stage
+wrangler secret put SERWERSMS_PASSWORD --env stage
+# ... itd.
+```
+
+Skrypt `sync-secrets.sh` automatyzuje masowe wstrzykiwanie sekretow.
+
+### Srodowiska GitHub
+
+| Srodowisko | URL | Ochrona | Wyzwalane przez |
+|-----------|-----|---------|-----------------|
+| `stage` | https://stage.powiadomienia.info | Brak (otwarte) | Push do main, workflow_dispatch |
+| `production` | https://powiadomienia.info | Wymagany recenzent: tkowalczyk | Wylacznie workflow_dispatch |
+
+### Ochrona brancha main
+
+- Wymagany status check: "Lint + Test + Quality" (nazwa joba `ci`)
+- Zakaz force push
+- Zakaz usuwania brancha
+
+---
+
+## 9. Typowe przeplyw pracy developera
+
+### Otwarcie PR
+
+1. Push brancha feature i otwarcie PR do `main`.
+2. GitHub automatycznie uruchamia `ci.yml`.
+3. Job `neon-branch` tworzy efemerycza galaz Neon `ci/pr-{N}`.
+4. Job `ci` instaluje zaleznosci, buduje `data-ops`, uruchamia Biome i Vitest z `TEST_DB_PROFILE=managed`.
+5. Status check "Lint + Test + Quality" musi byc zielony przed mozliwoscia merge.
+6. Po zakonczeniu CI (bez wzgledu na wynik) job `cleanup-neon-branch` usuwa galaz Neon.
+
+### Zmergowanie PR
+
+1. Po merge do `main` uruchamiaja sie rownolegle:
+   - `ci.yml` (push trigger) — testy z PGLite (szybkie, bez Neon).
+   - `deploy-stage.yml` (push trigger) — deploy obu aplikacji na stage.
+2. Stage jest dostepny pod `https://stage.powiadomienia.info` po kilku minutach.
+
+### Deploy na produkcje
+
+1. Przejdz do zakladki **Actions** w repozytorium GitHub.
+2. Wybierz workflow **"Deploy Production"**.
+3. Kliknij **"Run workflow"**.
+4. Opcjonalnie podaj `ref` (domyslnie: `main`).
+5. GitHub pyta recenzenta (tkowalczyk) o zatwierdzenie.
+6. Po zatwierdzeniu job deployuje obie aplikacje na `https://powiadomienia.info`.
+
+### Uruchamianie testow lokalnie
+
+**Profil lokalny (PGLite, domyslny):**
+```bash
+pnpm test
+# lub jawnie:
+TEST_DB_PROFILE=local pnpm test
+```
+
+Brak zaleznosci zewnetrznych. Testy uzywaja in-memory Postgres emulowanego przez PGLite.
+
+**Profil managed (Neon):**
+```bash
+TEST_DB_PROFILE=managed TEST_DATABASE_URL="postgres://..." pnpm test
+```
+
+`TEST_DATABASE_URL` musi wskazywac na galaz Neon, do ktorej developer ma dostep. Migracje sa aplikowane automatycznie przy kazdym uruchomieniu.
+
+### Dodanie nowej tabeli do schematu
+
+Schemat i migracje w `packages/data-ops` automatycznie przeplywaja do testow bez zadnej dodatkowej konfiguracji:
+
+```
+1. Edytuj packages/data-ops/src/drizzle/schema.ts
+         |
+         v
+2. Wygeneruj migracjê:
+   cd packages/data-ops
+   pnpm drizzle:dev:generate
+         |
+         v
+3. Zastosuj migracjê:
+   pnpm drizzle:dev:migrate
+         |
+         v
+4. Przebuduj data-ops:
+   pnpm build:data-ops
+         |
+         v
+5. Testy automatycznie widza nowy schemat
+   (test-harness stosuje migrations/dev/ przy kazdym createTestDb())
+```
+
+---
+
+## 10. Testy hygieniczno-kontraktowe (`repo-hygiene.test.ts`)
+
+Plik `packages/test-harness/tests/repo-hygiene.test.ts` zawiera testy ktore weryfikuja ze pipeline jest poprawnie skonfigurowany. Sa to testy kontraktowe M1-P2:
+
+- Biome jest skonfigurowany (`biome.json` istnieje).
+- Knip jest skonfigurowany (`knip.json` istnieje).
+- Taze jest skonfigurowany (`taze.config.ts` istnieje).
+- Skrypty `lint`, `lint:ci`, `knip`, `deps`, `types` istnieja w `package.json` w korzeniu.
+- Pliki `ci.yml`, `deploy-stage.yml`, `deploy-prod.yml` istnieja.
+
+Dzieki temu usuwanie plikow konfiguracyjnych lub zmiana nazw skryptow jest wykrywana w CI zanim ktokolwiek zorientuje sie ze cos jest nie tak.
+
+---
+
+## 11. Odniesienia
+
+- `.github/workflows/ci.yml` — pelny workflow CI
+- `.github/workflows/deploy-stage.yml` — deploy na staging
+- `.github/workflows/deploy-prod.yml` — deploy na produkcje
+- `packages/test-harness/src/db.ts` — implementacja dual-profile
+- `packages/data-ops/src/database/setup.ts` — seam do wstrzykiwania bazy
+- `packages/data-ops/src/drizzle/migrations/dev/` — zrodlo migracji dla testow
+- `packages/test-harness/tests/repo-hygiene.test.ts` — testy kontraktowe CI
+- `packages/test-harness/tests/managed-profile.test.ts` — testy profilu Neon
+- `biome.json` — konfiguracja Biome (zakres i reguly)
+- `plans/m1-fundament.md` — plan M1 w ktorym pipeline zostal zbudowany

--- a/skills/setup-ci/SKILL.md
+++ b/skills/setup-ci/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: setup-ci
+description: Set up a complete CI/CD pipeline for a pnpm monorepo deployed to Cloudflare Workers with Neon Postgres. Creates GitHub Actions workflows (CI gate, stage auto-deploy, prod manual deploy), quality gate tooling (Biome, Knip, Taze), test-harness with dual DB profile (PGLite local / Neon ephemeral branches), secrets management, branch protection, and environment approval gates.
+---
+
+# CI/CD Pipeline Setup
+
+Sets up production-grade CI/CD for **pnpm monorepo + Cloudflare Workers + Neon Postgres** projects in one session.
+
+## Usage
+
+```
+/setup-ci            — full interactive setup from scratch
+/setup-ci --audit    — audit existing setup, report gaps, fix them
+```
+
+## What gets created
+
+| Category | Files | Purpose |
+|----------|-------|---------|
+| CI workflow | `.github/workflows/ci.yml` | PR gate: Neon branch + lint + test + advisory checks |
+| Stage deploy | `.github/workflows/deploy-stage.yml` | Auto-deploy on merge to main |
+| Prod deploy | `.github/workflows/deploy-prod.yml` | Manual deploy with reviewer approval |
+| Lint | `biome.json` | Biome linter + formatter config |
+| Dead code | `knip.json` | Unused code/deps detector |
+| Dep freshness | `taze.config.ts` | Minor-version dependency staleness |
+| Test harness | `packages/test-harness/src/db.ts` | Dual PGLite/Neon DB factory |
+| Docs | `.github/SECRETS.md` | Required secrets, environments, branch protection |
+| Scripts | `package.json` (root) | `lint`, `lint:ci`, `knip`, `deps`, `types` scripts |
+
+## Workflow
+
+### 1. Discovery (ask before generating)
+
+Collect project-specific values. Do NOT generate files until all answers are confirmed.
+
+**Questions to ask:**
+
+1. **Monorepo layout** — "Which packages deploy as Cloudflare Workers? List the app directories (e.g. `apps/data-service`, `apps/user-application`)."
+
+2. **Database** — "Is Neon Postgres already set up? Is the Neon GitHub integration connected to this repo?" Verify with:
+   ```bash
+   gh secret list | grep NEON
+   gh variable list | grep NEON
+   ```
+   If not connected, guide user to: Neon Console → Project → Integrations → GitHub → connect repo.
+
+3. **Cloudflare** — "Do you have `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as GitHub secrets?" Verify with:
+   ```bash
+   gh secret list | grep CLOUDFLARE
+   ```
+   If not: guide user to create API token at https://dash.cloudflare.com/profile/api-tokens (template: "Edit Cloudflare Workers"), get account ID via `pnpm exec wrangler whoami`.
+
+4. **Environments** — "What are your environment names in wrangler.jsonc? (e.g. `stage`, `prod`)"
+
+5. **Deploy commands** — "What commands deploy each app to each env?" Check existing `package.json` scripts. Typical: `wrangler deploy --env stage`.
+
+6. **Data-ops package** — "Where is the drizzle schema? Where are dev migrations?" Typical: `packages/data-ops/src/drizzle/schema.ts`, `packages/data-ops/src/drizzle/migrations/dev/`.
+
+7. **Test harness** — "Does `packages/test-harness` already exist?" If yes, check for dual profile support. If no, create it.
+
+8. **Production reviewer** — "Who should approve production deploys?" Get their GitHub username.
+
+### 2. Generate files
+
+After confirming answers, generate all files. Use the reference templates in `references/` — adapt them to the project's specifics (app names, deploy commands, migration paths, environment names).
+
+**Generation order matters:**
+
+1. `biome.json` → `knip.json` → `taze.config.ts` (quality gate configs)
+2. Root `package.json` scripts (`lint`, `lint:ci`, `knip`, `deps`, `types`)
+3. `packages/test-harness/src/db.ts` (dual DB profile)
+4. `packages/test-harness/tests/managed-profile.test.ts` (conditional Neon test)
+5. `.github/workflows/ci.yml` (depends on test-harness existing)
+6. `.github/workflows/deploy-stage.yml`
+7. `.github/workflows/deploy-prod.yml`
+8. `.github/SECRETS.md`
+
+After generating, run:
+```bash
+pnpm install                    # install new devDeps
+pnpm exec biome check --write . # format generated files
+pnpm test                       # verify local profile works
+pnpm lint:ci                    # verify lint passes
+```
+
+### 3. Configure GitHub (interactive, requires user confirmation)
+
+These commands modify shared state — confirm each before running.
+
+```bash
+# Environments
+gh api -X PUT "repos/:owner/:repo/environments/stage"
+gh api -X PUT "repos/:owner/:repo/environments/production" --input - <<EOF
+{
+  "reviewers": [{"type": "User", "id": $(gh api user -q .id)}],
+  "deployment_branch_policy": {"protected_branches": true, "custom_branch_policies": false}
+}
+EOF
+
+# Branch protection (run AFTER first CI passes on main)
+gh api -X PUT "repos/:owner/:repo/branches/main/protection" --input - <<EOF
+{
+  "required_status_checks": {"strict": true, "contexts": ["Lint + Test + Quality"]},
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+### 4. Verify
+
+Open a test PR to verify the full pipeline:
+
+```bash
+git checkout -b test/ci-pipeline
+echo "# test" >> .github/SECRETS.md
+git add . && git commit -m "test: verify CI pipeline"
+git push -u origin test/ci-pipeline
+gh pr create --title "test: verify CI pipeline" --body "Testing CI. Will close after green."
+```
+
+Watch the run:
+```bash
+gh run list --branch test/ci-pipeline --limit 1
+gh run watch <run-id> --exit-status
+```
+
+Expected result:
+- `Create Neon Branch` — green (ephemeral branch created)
+- `Lint + Test + Quality` — green (all hard gates pass)
+- `Delete Neon Branch` — green (cleanup)
+
+After green: close the PR without merging (`gh pr close`).
+
+## Architecture reference
+
+See [ci-pipeline-architecture.md](./references/ci-pipeline-architecture.md) for the full pipeline architecture diagram and detailed explanation of each component.
+
+## Biome scope strategy
+
+When adding Biome to a project with existing code:
+
+1. **Start narrow** — exclude legacy directories (`!apps`, `!packages/legacy-pkg`) in `biome.json` `files.includes`
+2. **New code only** — all new packages/files are covered from day one
+3. **Ramp up incrementally** — after each cleanup phase, remove one exclusion
+4. **Rules severity** — start problematic rules as `"warn"`, flip to `"error"` after cleanup
+5. **Never `--write --unsafe` on existing code** — it changes semantics (e.g. `!.` to `?.`)
+
+## Test-harness design
+
+See [test-harness-pattern.md](./references/test-harness-pattern.md) for the dual-profile pattern, migration bootstrap, and injection seam.
+
+## Secrets management
+
+Two categories — never mix them:
+
+| Category | Lives in | Managed by | Example |
+|----------|----------|------------|---------|
+| CI/deploy secrets | GitHub Secrets/Variables | Neon integration (auto) + manual | `NEON_API_KEY`, `CLOUDFLARE_API_TOKEN` |
+| App runtime secrets | Cloudflare Workers (per-env) | `sync-secrets.sh` + `wrangler secret put` | `DATABASE_HOST`, `SERWERSMS_API_TOKEN` |
+
+CI/deploy secrets enable the pipeline. App runtime secrets are opaque to CI — they live in Cloudflare and survive across deploys.
+
+## Acceptance checklist
+
+After `/setup-ci` completes, verify:
+
+```
+[ ] `pnpm lint:ci` exits 0
+[ ] `pnpm test` exits 0 (local PGLite profile)
+[ ] `pnpm knip` runs (advisory, may report findings)
+[ ] `pnpm deps` runs (advisory)
+[ ] `pnpm types` runs (advisory)
+[ ] `.github/workflows/ci.yml` exists and is valid YAML
+[ ] `.github/workflows/deploy-stage.yml` exists
+[ ] `.github/workflows/deploy-prod.yml` exists
+[ ] `NEON_API_KEY` secret exists in repo (`gh secret list`)
+[ ] `NEON_PROJECT_ID` variable exists in repo (`gh variable list`)
+[ ] `CLOUDFLARE_API_TOKEN` secret exists in repo
+[ ] `CLOUDFLARE_ACCOUNT_ID` secret exists in repo
+[ ] GitHub environment `stage` exists
+[ ] GitHub environment `production` exists with required reviewer
+[ ] Branch protection on `main` with required CI check
+[ ] Test PR opened → CI green → PR closed
+```

--- a/skills/setup-ci/references/ci-pipeline-architecture.md
+++ b/skills/setup-ci/references/ci-pipeline-architecture.md
@@ -1,0 +1,279 @@
+# CI/CD Pipeline Architecture
+
+Reference document for the `/setup-ci` skill. Describes the full pipeline that gets created.
+
+## Pipeline overview
+
+```
+PR opened/updated
+     │
+     ├─► ci.yml
+     │   ├── Job: Create Neon Branch (PRs only)
+     │   │   └── neondatabase/create-branch-action@v6
+     │   │       inputs: project_id, api_key
+     │   │       outputs: db_url_with_pooler, branch_id
+     │   │
+     │   ├── Job: Lint + Test + Quality
+     │   │   ├── pnpm install --frozen-lockfile
+     │   │   ├── build shared packages (e.g. data-ops)
+     │   │   ├── [HARD] biome ci .
+     │   │   ├── [HARD] pnpm test
+     │   │   │   env: TEST_DB_PROFILE=managed (PR) or local (push)
+     │   │   │   env: TEST_DATABASE_URL=<neon branch url> (PR only)
+     │   │   ├── [advisory] pnpm types
+     │   │   ├── [advisory] pnpm knip
+     │   │   └── [advisory] pnpm deps
+     │   │
+     │   └── Job: Delete Neon Branch (PRs only, always() runs)
+     │       └── neondatabase/delete-branch-action@v3
+     │
+     ▼
+Branch protection check: "Lint + Test + Quality" green?
+     │
+     ├── NO → merge blocked
+     └── YES → merge allowed
+              │
+              ▼
+         push to main
+              │
+              ├─► ci.yml (push trigger)
+              │   └── Same jobs, but Neon branch skipped
+              │       Tests run on local PGLite (fast, no network)
+              │
+              └─► deploy-stage.yml
+                  ├── wrangler deploy --env stage (app 1)
+                  └── wrangler deploy --env stage (app 2)
+                  → stage.example.com updated
+
+Manual trigger (Actions tab → "Deploy Production" → Run workflow)
+     │
+     └─► deploy-prod.yml
+         │ environment: production (requires reviewer approval)
+         ├── wrangler deploy --env prod (app 1)
+         └── wrangler deploy --env prod (app 2)
+         → example.com updated
+```
+
+## Neon branching model
+
+```
+Neon project "main" branch (source of truth)
+     │
+     ├── ci/pr-42  (ephemeral, created by CI, deleted on PR close)
+     ├── ci/pr-43  (ephemeral, created by CI, deleted on PR close)
+     └── ci/pr-44  (ephemeral, created by CI, deleted on PR close)
+
+Each branch is:
+- Instant (copy-on-write, no data duplication)
+- Isolated (writes don't affect main or other branches)
+- Cheap (no storage cost until writes diverge)
+- Auto-cleaned (deleted by CI on PR close)
+```
+
+## ci.yml template
+
+```yaml
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  neon-branch:
+    name: Create Neon Branch
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      db_url: ${{ steps.create.outputs.db_url_with_pooler }}
+      branch_id: ${{ steps.create.outputs.branch_id }}
+    steps:
+      - name: Create ephemeral Neon branch
+        id: create
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch_name: ci/pr-${{ github.event.pull_request.number }}
+
+  ci:
+    name: Lint + Test + Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [neon-branch]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # -- Adapt this section to your project --
+      - name: Build shared packages
+        run: pnpm run build:data-ops
+
+      - name: Lint
+        run: pnpm run lint:ci
+
+      - name: Tests
+        env:
+          TEST_DATABASE_URL: ${{ needs.neon-branch.outputs.db_url }}
+          TEST_DB_PROFILE: ${{ needs.neon-branch.outputs.db_url && 'managed' || 'local' }}
+        run: pnpm run test
+
+      # Advisory gates (adapt to your tooling)
+      - name: Typecheck
+        continue-on-error: true
+        run: pnpm run types
+      - name: Dead code
+        continue-on-error: true
+        run: pnpm run knip
+      - name: Dep freshness
+        continue-on-error: true
+        run: pnpm run deps
+
+  cleanup-neon-branch:
+    name: Delete Neon Branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [neon-branch, ci]
+    if: always() && needs.neon-branch.outputs.branch_id
+    steps:
+      - uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          branch: ${{ needs.neon-branch.outputs.branch_id }}
+```
+
+## deploy-stage.yml template
+
+```yaml
+name: Deploy Stage
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-stage
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: stage
+      url: https://stage.example.com
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:data-ops
+      # -- Adapt: one step per deployable app --
+      - name: Deploy app-1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm run deploy:stage:app-1
+      - name: Deploy app-2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm run deploy:stage:app-2
+```
+
+## deploy-prod.yml template
+
+```yaml
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy (defaults to main)"
+        required: false
+        default: main
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: production
+      url: https://example.com
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || 'main' }}
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:data-ops
+      # -- Adapt: one step per deployable app --
+      - name: Deploy app-1
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm run deploy:prod:app-1
+      - name: Deploy app-2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm run deploy:prod:app-2
+```
+
+## Required GitHub configuration
+
+### Secrets (Settings → Secrets and variables → Actions)
+
+| Name | Source | Required by |
+|------|--------|-------------|
+| `NEON_API_KEY` | Auto (Neon GH integration) | ci.yml |
+| `CLOUDFLARE_API_TOKEN` | Manual | deploy-stage/prod.yml |
+| `CLOUDFLARE_ACCOUNT_ID` | Manual | deploy-stage/prod.yml |
+
+### Variables
+
+| Name | Source | Required by |
+|------|--------|-------------|
+| `NEON_PROJECT_ID` | Auto (Neon GH integration) | ci.yml |
+
+### Environments
+
+| Name | Reviewers | Branch policy | Used by |
+|------|-----------|---------------|---------|
+| `stage` | none | any | deploy-stage.yml |
+| `production` | owner | protected only | deploy-prod.yml |
+
+### Branch protection (main)
+
+| Setting | Value |
+|---------|-------|
+| Required status checks | `Lint + Test + Quality` (strict) |
+| Force pushes | blocked |
+| Deletions | blocked |

--- a/skills/setup-ci/references/test-harness-pattern.md
+++ b/skills/setup-ci/references/test-harness-pattern.md
@@ -1,0 +1,235 @@
+# Test-Harness Dual DB Profile Pattern
+
+Reference document for the `/setup-ci` skill. Describes the test-harness
+`createTestDb()` pattern that gives every test a real-shape Postgres
+database backed by either PGLite (local, fast) or Neon (CI, real Postgres).
+
+## Core idea
+
+One function, two backends, same migrations, same interface.
+
+```
+createTestDb()
+     │
+     ├── TEST_DB_PROFILE=local → PGLite (in-memory, no network)
+     │   └── drizzle-orm/pglite + drizzle-orm/pglite/migrator
+     │
+     └── TEST_DB_PROFILE=managed → Neon HTTP (real Postgres, needs URL)
+         └── @neondatabase/serverless + drizzle-orm/neon-http + migrator
+```
+
+Both profiles:
+- Apply the SAME migration set from the data-ops package
+- Return the SAME `TestDbHandle` type (`{ db: PgDatabase, cleanup() }`)
+- Are interchangeable from the caller's perspective
+
+## db.ts template
+
+```typescript
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { neon } from "@neondatabase/serverless";
+import type { PgDatabase } from "drizzle-orm/pg-core";
+import { drizzle as drizzleNeon } from "drizzle-orm/neon-http";
+import { migrate as migrateNeon } from "drizzle-orm/neon-http/migrator";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
+
+export type TestDb = PgDatabase<any, any, any>;
+
+export interface TestDbHandle {
+  db: TestDb;
+  cleanup: () => Promise<void>;
+}
+
+type Profile = "local" | "managed";
+
+function resolveProfile(): Profile {
+  const raw = process.env.TEST_DB_PROFILE ?? "local";
+  if (raw === "local" || raw === "managed") return raw;
+  throw new Error(
+    `Unknown TEST_DB_PROFILE=${raw}. Expected "local" or "managed".`
+  );
+}
+
+// Resolve migration path relative to THIS file, not cwd.
+// Adapt the relative path to your project's layout.
+const MIGRATIONS_FOLDER = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../data-ops/src/drizzle/migrations/dev"
+);
+
+async function createLocalDb(): Promise<TestDbHandle> {
+  const pg = new PGlite();
+  const db = drizzlePglite(pg) as unknown as TestDb;
+  await migratePglite(drizzlePglite(pg), {
+    migrationsFolder: MIGRATIONS_FOLDER,
+  });
+
+  let closed = false;
+  return {
+    db,
+    cleanup: async () => {
+      if (closed) return;
+      closed = true;
+      await pg.close();
+    },
+  };
+}
+
+async function createManagedDb(): Promise<TestDbHandle> {
+  const url = process.env.TEST_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "TEST_DB_PROFILE=managed requires TEST_DATABASE_URL."
+    );
+  }
+
+  const sqlClient = neon(url);
+  const db = drizzleNeon(sqlClient) as unknown as TestDb;
+  await migrateNeon(drizzleNeon(sqlClient), {
+    migrationsFolder: MIGRATIONS_FOLDER,
+  });
+
+  return { db, cleanup: async () => {} };
+}
+
+export async function createTestDb(): Promise<TestDbHandle> {
+  const profile = resolveProfile();
+  if (profile === "managed") return createManagedDb();
+  return createLocalDb();
+}
+```
+
+## Injection seam in data-ops
+
+The data-ops package must expose a way to inject a test DB into its
+global slot. This is the bridge between test-harness and query code.
+
+```typescript
+// data-ops/database/setup.ts
+
+let db: PgDatabase | undefined;
+
+// Production path
+export function initDatabase(config: ConnectionConfig): PgDatabase;
+// Test injection path
+export function initDatabase(config: { client: PgDatabase }): PgDatabase;
+
+export function initDatabase(config) {
+  if (db) return db;
+  if ("client" in config) { db = config.client; return db; }
+  // ... production Neon HTTP connection
+}
+
+export function getDb(): PgDatabase {
+  if (!db) throw new Error("Database not initialized");
+  return db;
+}
+
+// Tests call this between runs
+export function resetDatabase(): void { db = undefined; }
+```
+
+## Test pattern
+
+```typescript
+// data-ops/tests/integration/example.test.ts
+import { createTestDb, type TestDbHandle } from "@repo/test-harness";
+import { initDatabase, resetDatabase } from "@/database/setup";
+import { cities } from "@/drizzle/schema";
+import { getCities } from "@/queries/address";
+
+describe("example roundtrip", () => {
+  let handle: TestDbHandle;
+
+  beforeEach(async () => {
+    handle = await createTestDb();
+    resetDatabase();
+    initDatabase({ client: handle.db });
+  });
+
+  afterEach(async () => {
+    resetDatabase();
+    await handle.cleanup();
+  });
+
+  it("queries return inserted rows", async () => {
+    await handle.db.insert(cities).values({ name: "Test" });
+    const result = await getCities();
+    expect(result[0].name).toBe("Test");
+  });
+});
+```
+
+## Managed-profile-only test (conditional)
+
+```typescript
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL;
+
+describe.runIf(TEST_DATABASE_URL)("managed profile", () => {
+  let handle: TestDbHandle;
+
+  beforeEach(() => { vi.stubEnv("TEST_DB_PROFILE", "managed"); });
+  afterEach(async () => {
+    if (handle) await handle.cleanup();
+    vi.unstubAllEnvs();
+  });
+
+  it("connects to real Postgres", async () => {
+    handle = await createTestDb();
+    const result = await handle.db.execute(sql`select 1 as one`);
+    expect(result).toBeDefined();
+  });
+});
+```
+
+## Dependencies (test-harness package.json)
+
+```json
+{
+  "dependencies": {
+    "@electric-sql/pglite": "^0.2.17",
+    "@neondatabase/serverless": "^1.0.2",
+    "drizzle-orm": "^0.44.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.x"
+  }
+}
+```
+
+## Migration bootstrap: why migrations, not raw DDL
+
+The original tracer bullet used raw `CREATE TABLE` in test-harness:
+
+```typescript
+// BAD: hand-rolled DDL drifts from schema.ts
+await pg.exec(`CREATE TABLE cities (id SERIAL PRIMARY KEY, ...)`);
+```
+
+Problem: every time you add a table to `schema.ts` and generate a
+migration, you ALSO have to update test-harness. Two sources of truth
+that drift apart.
+
+Solution: use drizzle's migrator to apply the same `.sql` files that
+production uses:
+
+```typescript
+// GOOD: single source of truth
+await migratePglite(db, { migrationsFolder: MIGRATIONS_FOLDER });
+```
+
+The migrator:
+- Reads every `.sql` file from the folder, ordered by filename
+- Tracks which migrations have been applied in `__drizzle_migrations` table
+- Is idempotent — running twice is safe
+- Works identically on PGLite and Neon HTTP
+
+This means adding a table is a one-step process:
+1. Edit `schema.ts` → `pnpm drizzle:dev:generate` → new `.sql` appears
+2. Tests automatically see the new table on next run
+
+Zero test-harness edits required.


### PR DESCRIPTION
## Summary

- **`docs/ci-cd-pipeline.md`** — complete pipeline documentation in Polish covering all workflows, test-harness, quality gates, secrets management, and developer flows
- **`skills/setup-ci/`** — reusable Claude Code skill for setting up the same CI/CD pipeline on any pnpm monorepo + CF Workers + Neon project

No code changes, documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)