### PR TITLE
feat: fixture factories for core domain entities (M1-P1.6)

### DIFF
--- a/packages/test-harness/src/fixtures.test.ts
+++ b/packages/test-harness/src/fixtures.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestDb, type TestDbHandle } from "./db";
+import {
+	createHousehold,
+	createHouseholdRole,
+	createHouseholdMember,
+	createChannel,
+	createNotificationSource,
+} from "./fixtures";
+
+describe("fixture factories", () => {
+	let handle: TestDbHandle;
+
+	beforeAll(async () => {
+		handle = await createTestDb();
+	});
+
+	afterAll(async () => {
+		await handle.cleanup();
+	});
+
+	it("creates a household with defaults", async () => {
+		const row = await createHousehold(handle.db);
+		expect(row.id).toBeTypeOf("number");
+		expect(row.name).toBeTypeOf("string");
+		expect(row.name.length).toBeGreaterThan(0);
+	});
+
+	it("creates a household with overrides", async () => {
+		const row = await createHousehold(handle.db, { name: "Kowalski" });
+		expect(row.name).toBe("Kowalski");
+	});
+
+	it("creates a household role with defaults", async () => {
+		const row = await createHouseholdRole(handle.db);
+		expect(row.id).toBeTypeOf("number");
+		expect(row.name).toBeTypeOf("string");
+	});
+
+	it("creates a household member linked to household, user and role", async () => {
+		const household = await createHousehold(handle.db);
+		const role = await createHouseholdRole(handle.db);
+		const member = await createHouseholdMember(handle.db, {
+			householdId: household.id,
+			roleId: role.id,
+		});
+		expect(member.id).toBeTypeOf("number");
+		expect(member.householdId).toBe(household.id);
+		expect(member.roleId).toBe(role.id);
+		expect(member.userId).toBeTypeOf("string");
+	});
+
+	it("creates a channel linked to household", async () => {
+		const household = await createHousehold(handle.db);
+		const channel = await createChannel(handle.db, { householdId: household.id });
+		expect(channel.id).toBeTypeOf("number");
+		expect(channel.householdId).toBe(household.id);
+		expect(channel.type).toBeTypeOf("string");
+		expect(channel.enabled).toBe(true);
+	});
+
+	it("creates a notification source linked to household", async () => {
+		const household = await createHousehold(handle.db);
+		const source = await createNotificationSource(handle.db, { householdId: household.id });
+		expect(source.id).toBeTypeOf("number");
+		expect(source.householdId).toBe(household.id);
+		expect(source.name).toBeTypeOf("string");
+		expect(source.type).toBeTypeOf("string");
+		expect(source.enabled).toBe(true);
+	});
+
+	it("creates notification source with overrides", async () => {
+		const household = await createHousehold(handle.db);
+		const source = await createNotificationSource(handle.db, {
+			householdId: household.id,
+			name: "Waste Collection",
+			type: "waste",
+			enabled: false,
+			config: { schedule: "weekly" },
+		});
+		expect(source.name).toBe("Waste Collection");
+		expect(source.type).toBe("waste");
+		expect(source.enabled).toBe(false);
+		expect(source.config).toEqual({ schedule: "weekly" });
+	});
+});

--- a/packages/test-harness/src/fixtures.ts
+++ b/packages/test-harness/src/fixtures.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import type { TestDb } from "./db";
+import { pgTable, serial, text, timestamp, boolean, integer, index, jsonb } from "drizzle-orm/pg-core";
+
+// ─── Inline table references ──────────────────────────────────────────
+// We duplicate the minimal table definitions here instead of importing from
+// data-ops to keep the test-harness free of build-order dependencies on
+// data-ops dist/. The shapes mirror data-ops/src/drizzle/schema.ts and
+// auth-schema.ts — if schema changes, these must be updated too.
+
+const auth_user = pgTable("auth_user", {
+	id: text("id").primaryKey(),
+	name: text("name").notNull(),
+	email: text("email").notNull(),
+	emailVerified: boolean("email_verified").default(false).notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+const households = pgTable("households", {
+	id: serial("id").primaryKey(),
+	name: text("name").notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+const householdRoles = pgTable("household_roles", {
+	id: serial("id").primaryKey(),
+	name: text("name").notNull(),
+	description: text("description"),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+const householdMembers = pgTable("household_members", {
+	id: serial("id").primaryKey(),
+	householdId: integer("household_id").notNull(),
+	userId: text("user_id").notNull(),
+	roleId: integer("role_id").notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+const channels = pgTable("channels", {
+	id: serial("id").primaryKey(),
+	householdId: integer("household_id").notNull(),
+	type: text("type").notNull(),
+	config: jsonb("config").notNull().default({}),
+	enabled: boolean("enabled").default(true).notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+const notificationSources = pgTable("notification_sources", {
+	id: serial("id").primaryKey(),
+	householdId: integer("household_id").notNull(),
+	name: text("name").notNull(),
+	type: text("type").notNull(),
+	config: jsonb("config").notNull().default({}),
+	enabled: boolean("enabled").default(true).notNull(),
+	createdAt: timestamp("created_at").defaultNow().notNull(),
+	updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// ─── Counters for unique defaults ──────────────────────────────────────
+let counter = 0;
+function next(): number {
+	return ++counter;
+}
+
+// ─── Factory functions ─────────────────────────────────────────────────
+
+export async function createHousehold(
+	db: TestDb,
+	overrides: { name?: string } = {},
+) {
+	const [row] = await db
+		.insert(households)
+		.values({ name: overrides.name ?? `Test Household ${next()}` })
+		.returning();
+	return row!;
+}
+
+export async function createHouseholdRole(
+	db: TestDb,
+	overrides: { name?: string; description?: string } = {},
+) {
+	const n = next();
+	const [row] = await db
+		.insert(householdRoles)
+		.values({
+			name: overrides.name ?? `role-${n}`,
+			description: overrides.description ?? null,
+		})
+		.returning();
+	return row!;
+}
+
+export async function createHouseholdMember(
+	db: TestDb,
+	overrides: { householdId: number; roleId: number; userId?: string },
+) {
+	const userId = overrides.userId ?? (await createTestUser(db)).id;
+	const [row] = await db
+		.insert(householdMembers)
+		.values({
+			householdId: overrides.householdId,
+			userId,
+			roleId: overrides.roleId,
+		})
+		.returning();
+	return row!;
+}
+
+export async function createChannel(
+	db: TestDb,
+	overrides: {
+		householdId: number;
+		type?: string;
+		config?: Record<string, unknown>;
+		enabled?: boolean;
+	},
+) {
+	const [row] = await db
+		.insert(channels)
+		.values({
+			householdId: overrides.householdId,
+			type: overrides.type ?? "noop",
+			config: overrides.config ?? {},
+			enabled: overrides.enabled ?? true,
+		})
+		.returning();
+	return row!;
+}
+
+export async function createNotificationSource(
+	db: TestDb,
+	overrides: {
+		householdId: number;
+		name?: string;
+		type?: string;
+		config?: Record<string, unknown>;
+		enabled?: boolean;
+	},
+) {
+	const n = next();
+	const [row] = await db
+		.insert(notificationSources)
+		.values({
+			householdId: overrides.householdId,
+			name: overrides.name ?? `Test Source ${n}`,
+			type: overrides.type ?? "test",
+			config: overrides.config ?? {},
+			enabled: overrides.enabled ?? true,
+		})
+		.returning();
+	return row!;
+}
+
+// ─── Helper: create a minimal auth_user for FK satisfaction ────────────
+
+async function createTestUser(db: TestDb) {
+	const id = randomUUID();
+	const n = next();
+	const [row] = await db
+		.insert(auth_user)
+		.values({
+			id,
+			name: `Test User ${n}`,
+			email: `test-${n}-${id.slice(0, 8)}@example.com`,
+			emailVerified: false,
+		})
+		.returning();
+	return row!;
+}

--- a/packages/test-harness/src/fixtures.ts
+++ b/packages/test-harness/src/fixtures.ts
@@ -1,6 +1,15 @@
 import { randomUUID } from "node:crypto";
 import type { TestDb } from "./db";
-import { pgTable, serial, text, timestamp, boolean, integer, index, jsonb } from "drizzle-orm/pg-core";
+import {
+	pgTable,
+	serial,
+	text,
+	timestamp,
+	boolean,
+	integer,
+	index,
+	jsonb,
+} from "drizzle-orm/pg-core";
 
 // ─── Inline table references ──────────────────────────────────────────
 // We duplicate the minimal table definitions here instead of importing from
@@ -70,10 +79,7 @@ function next(): number {
 
 // ─── Factory functions ─────────────────────────────────────────────────
 
-export async function createHousehold(
-	db: TestDb,
-	overrides: { name?: string } = {},
-) {
+export async function createHousehold(db: TestDb, overrides: { name?: string } = {}) {
 	const [row] = await db
 		.insert(households)
 		.values({ name: overrides.name ?? `Test Household ${next()}` })

--- a/packages/test-harness/src/index.ts
+++ b/packages/test-harness/src/index.ts
@@ -1,2 +1,9 @@
 export { createTestDb } from "./db";
 export type { TestDb, TestDbHandle } from "./db";
+export {
+	createHousehold,
+	createHouseholdRole,
+	createHouseholdMember,
+	createChannel,
+	createNotificationSource,
+} from "./fixtures";


### PR DESCRIPTION
## Summary
- Adds composable test factories for all 4 core domain entities: `createHousehold`, `createHouseholdRole`, `createHouseholdMember`, `createChannel`, `createNotificationSource`
- Factories auto-create FK dependencies (e.g. `createHouseholdMember` creates a test `auth_user` if none provided)
- Exported from `test-harness` index for use across all packages
- Closes #14 (M1-P1.6: deferred AC #6 from original P1)

## Test plan
- [x] 7 unit tests covering defaults, overrides, FK linking
- [x] Full test-harness suite green (35 passed, 2 skipped)
- [ ] CI runs lint + types + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)