### PR TITLE
feat: Admin UI — notification sources CRUD (M2-P5)

### DIFF
--- a/apps/data-service/src/hono/app.ts
+++ b/apps/data-service/src/hono/app.ts
@@ -5,6 +5,7 @@ import { createCorsMiddleware } from "./middleware/cors";
 import { rateLimit } from "./middleware/rate-limit";
 import { healthHandler } from "./handlers/health";
 import { statsHandler } from "./handlers/stats";
+import { sourcesApp } from "./handlers/sources";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -19,3 +20,4 @@ app.use("/worker/*", rateLimit(100, 60_000));
 // Routes
 app.get("/worker/health", healthHandler);
 app.get("/worker/stats", statsHandler);
+app.route("/worker/sources", sourcesApp);

--- a/apps/data-service/src/hono/handlers/sources.test.ts
+++ b/apps/data-service/src/hono/handlers/sources.test.ts
@@ -39,7 +39,6 @@ vi.mock("@/domain/source-lifecycle", () => ({
 }));
 
 import { createNotificationSource } from "@repo/data-ops/queries/notification-sources";
-import { createSourceWithTopic } from "@/domain/source-lifecycle";
 
 describe("sources handler", () => {
 	let app: Hono;

--- a/apps/data-service/src/hono/handlers/sources.test.ts
+++ b/apps/data-service/src/hono/handlers/sources.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { sourcesApp } from "./sources";
+
+// Mock data-ops queries
+vi.mock("@repo/data-ops/queries/notification-sources", () => ({
+	createNotificationSource: vi.fn().mockResolvedValue({
+		id: 1,
+		householdId: 10,
+		name: "Wywóz — Kwiatowa",
+		type: "waste_collection",
+		config: { address: "ul. Kwiatowa 5", schedule: [{ type: "szkło", dates: ["2026-04-15"] }] },
+		alertBeforeHours: 18,
+		topicId: null,
+		enabled: true,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	}),
+	updateNotificationSource: vi.fn().mockResolvedValue({
+		id: 1,
+		name: "Updated",
+		type: "waste_collection",
+		config: {},
+		alertBeforeHours: 12,
+		topicId: 777,
+		enabled: true,
+	}),
+	deleteNotificationSource: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock source lifecycle
+vi.mock("@/domain/source-lifecycle", () => ({
+	createSourceWithTopic: vi.fn().mockResolvedValue({
+		id: 1,
+		name: "Wywóz — Kwiatowa",
+		type: "waste_collection",
+		topicId: 777,
+	}),
+}));
+
+import { createNotificationSource } from "@repo/data-ops/queries/notification-sources";
+import { createSourceWithTopic } from "@/domain/source-lifecycle";
+
+describe("sources handler", () => {
+	let app: Hono;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		app = new Hono();
+		app.route("/sources", sourcesApp);
+	});
+
+	it("POST /sources creates source without Telegram and returns 201", async () => {
+		const res = await app.request("/sources", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				householdId: 10,
+				name: "Wywóz — Kwiatowa",
+				type: "waste_collection",
+				config: { address: "ul. Kwiatowa 5", schedule: [{ type: "szkło", dates: ["2026-04-15"] }] },
+				alertBeforeHours: 18,
+			}),
+		});
+
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.id).toBe(1);
+		expect(createNotificationSource).toHaveBeenCalledOnce();
+	});
+
+	it("POST /sources rejects invalid config shape", async () => {
+		const res = await app.request("/sources", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				householdId: 10,
+				name: "Test",
+				type: "waste_collection",
+				config: { birthdays: [{ name: "X", date: "03-15" }] },
+			}),
+		});
+
+		expect(res.status).toBe(400);
+	});
+
+	it("PUT /sources/:id updates source", async () => {
+		const res = await app.request("/sources/1", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				name: "Updated",
+				alertBeforeHours: 12,
+			}),
+		});
+
+		expect(res.status).toBe(200);
+	});
+
+	it("DELETE /sources/:id deletes source", async () => {
+		const res = await app.request("/sources/1", {
+			method: "DELETE",
+		});
+
+		expect(res.status).toBe(204);
+	});
+});

--- a/apps/data-service/src/hono/handlers/sources.ts
+++ b/apps/data-service/src/hono/handlers/sources.ts
@@ -1,0 +1,72 @@
+import { Hono } from "hono";
+import {
+	createNotificationSource,
+	updateNotificationSource,
+	deleteNotificationSource,
+} from "@repo/data-ops/queries/notification-sources";
+import { SourceFormInput } from "@repo/data-ops/zod-schema/source-form-schema";
+import { UpdateNotificationSourceInput } from "@repo/data-ops/zod-schema/notification-source";
+import { createSourceWithTopic, type SourceLifecycleDeps } from "@/domain/source-lifecycle";
+import { TelegramChannel } from "@/channels/telegram";
+
+export const sourcesApp = new Hono<{ Bindings: Env }>();
+
+sourcesApp.post("/", async (c) => {
+	const body = await c.req.json();
+	const parsed = SourceFormInput.safeParse(body);
+
+	if (!parsed.success) {
+		return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+	}
+
+	const { name, type, config, alertBeforeHours } = parsed.data;
+	const householdId = body.householdId as number;
+
+	const chatId = c.env?.TELEGRAM_GROUP_CHAT_ID;
+	const botToken = c.env?.TELEGRAM_BOT_TOKEN;
+
+	if (chatId && botToken) {
+		const channel = new TelegramChannel({ botToken });
+		const deps: SourceLifecycleDeps = {
+			insertSource: (input) => createNotificationSource({ ...input, alertBeforeHours }),
+			createForumTopic: (cId, n, emoji) => channel.createForumTopic(cId, n, emoji),
+			updateSource: (sourceId, data) => updateNotificationSource(sourceId, data),
+		};
+
+		const result = await createSourceWithTopic(
+			{ householdId, name, type, config },
+			chatId,
+			deps,
+		);
+		return c.json(result, 201);
+	}
+
+	// Fallback: no Telegram config — just insert source
+	const source = await createNotificationSource({
+		householdId,
+		name,
+		type,
+		config,
+		alertBeforeHours,
+	});
+	return c.json(source, 201);
+});
+
+sourcesApp.put("/:id", async (c) => {
+	const id = Number(c.req.param("id"));
+	const body = await c.req.json();
+	const parsed = UpdateNotificationSourceInput.safeParse(body);
+
+	if (!parsed.success) {
+		return c.json({ error: "Invalid input", details: parsed.error.flatten() }, 400);
+	}
+
+	const updated = await updateNotificationSource(id, parsed.data);
+	return c.json(updated);
+});
+
+sourcesApp.delete("/:id", async (c) => {
+	const id = Number(c.req.param("id"));
+	await deleteNotificationSource(id);
+	return c.body(null, 204);
+});

--- a/apps/data-service/src/hono/handlers/sources.ts
+++ b/apps/data-service/src/hono/handlers/sources.ts
@@ -33,11 +33,7 @@ sourcesApp.post("/", async (c) => {
 			updateSource: (sourceId, data) => updateNotificationSource(sourceId, data),
 		};
 
-		const result = await createSourceWithTopic(
-			{ householdId, name, type, config },
-			chatId,
-			deps,
-		);
+		const result = await createSourceWithTopic({ householdId, name, type, config }, chatId, deps);
 		return c.json(result, 201);
 	}
 

--- a/apps/user-application/src/components/navigation/dashboard-nav.tsx
+++ b/apps/user-application/src/components/navigation/dashboard-nav.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from "@tanstack/react-router";
-import { Bell } from "lucide-react";
+import { Bell, ListChecks } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { authClient } from "@/lib/auth-client";
@@ -61,6 +61,12 @@ export function DashboardNav() {
 
 					{/* Desktop Navigation */}
 					<div className="hidden md:flex items-center space-x-4">
+						<Button variant="ghost" asChild>
+							<Link to="/app/sources" className="flex items-center gap-2">
+								<ListChecks className="h-4 w-4" />
+								{t("nav.sources", "Źródła")}
+							</Link>
+						</Button>
 						<AccountDialog>
 							<Button variant="ghost" className="flex items-center gap-2 px-3">
 								<Avatar className="h-7 w-7">

--- a/apps/user-application/src/components/sources/birthday-config-fields.tsx
+++ b/apps/user-application/src/components/sources/birthday-config-fields.tsx
@@ -63,19 +63,12 @@ export function BirthdayConfigFields({
 							placeholder="MM-DD"
 						/>
 					</div>
-					<Button
-						type="button"
-						variant="ghost"
-						size="sm"
-						onClick={() => removeEntry(index)}
-					>
+					<Button type="button" variant="ghost" size="sm" onClick={() => removeEntry(index)}>
 						<X className="h-4 w-4" />
 					</Button>
 				</div>
 			))}
-			{errors?.birthdays && (
-				<p className="text-sm text-destructive">{errors.birthdays}</p>
-			)}
+			{errors?.birthdays && <p className="text-sm text-destructive">{errors.birthdays}</p>}
 		</div>
 	);
 }

--- a/apps/user-application/src/components/sources/birthday-config-fields.tsx
+++ b/apps/user-application/src/components/sources/birthday-config-fields.tsx
@@ -1,0 +1,81 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Plus, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface BirthdayEntry {
+	name: string;
+	date: string;
+}
+
+interface BirthdayConfigFieldsProps {
+	birthdays: BirthdayEntry[];
+	onBirthdaysChange: (birthdays: BirthdayEntry[]) => void;
+	errors?: Record<string, string>;
+}
+
+export function BirthdayConfigFields({
+	birthdays,
+	onBirthdaysChange,
+	errors,
+}: BirthdayConfigFieldsProps) {
+	const { t } = useTranslation();
+
+	const addEntry = () => {
+		onBirthdaysChange([...birthdays, { name: "", date: "" }]);
+	};
+
+	const removeEntry = (index: number) => {
+		onBirthdaysChange(birthdays.filter((_, i) => i !== index));
+	};
+
+	const updateEntry = (index: number, field: keyof BirthdayEntry, value: string) => {
+		const updated = birthdays.map((entry, i) =>
+			i === index ? { name: entry.name, date: entry.date, [field]: value } : entry,
+		);
+		onBirthdaysChange(updated);
+	};
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between">
+				<Label>{t("sources.birthday.list", "Lista urodzin")}</Label>
+				<Button type="button" variant="outline" size="sm" onClick={addEntry}>
+					<Plus className="h-4 w-4 mr-1" />
+					{t("sources.birthday.add", "Dodaj osobę")}
+				</Button>
+			</div>
+
+			{birthdays.map((entry, index) => (
+				<div key={index} className="flex gap-2 items-start">
+					<div className="flex-1">
+						<Input
+							value={entry.name}
+							onChange={(e) => updateEntry(index, "name", e.target.value)}
+							placeholder={t("sources.birthday.name", "Imię")}
+						/>
+					</div>
+					<div className="w-32">
+						<Input
+							value={entry.date}
+							onChange={(e) => updateEntry(index, "date", e.target.value)}
+							placeholder="MM-DD"
+						/>
+					</div>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={() => removeEntry(index)}
+					>
+						<X className="h-4 w-4" />
+					</Button>
+				</div>
+			))}
+			{errors?.birthdays && (
+				<p className="text-sm text-destructive">{errors.birthdays}</p>
+			)}
+		</div>
+	);
+}

--- a/apps/user-application/src/components/sources/delete-source-dialog.tsx
+++ b/apps/user-application/src/components/sources/delete-source-dialog.tsx
@@ -40,9 +40,7 @@ export function DeleteSourceDialog({
 			</DialogTrigger>
 			<DialogContent>
 				<DialogHeader>
-					<DialogTitle>
-						{t("sources.deleteTitle", "Usuń źródło")}
-					</DialogTitle>
+					<DialogTitle>{t("sources.deleteTitle", "Usuń źródło")}</DialogTitle>
 					<DialogDescription>
 						{t(
 							"sources.deleteDescription",
@@ -53,18 +51,14 @@ export function DeleteSourceDialog({
 				</DialogHeader>
 				<DialogFooter>
 					<DialogClose asChild>
-						<Button variant="outline">
-							{t("common.cancel", "Anuluj")}
-						</Button>
+						<Button variant="outline">{t("common.cancel", "Anuluj")}</Button>
 					</DialogClose>
 					<Button
 						variant="destructive"
 						onClick={() => mutation.mutate()}
 						disabled={mutation.isPending}
 					>
-						{mutation.isPending
-							? t("common.deleting", "Usuwanie...")
-							: t("common.delete", "Usuń")}
+						{mutation.isPending ? t("common.deleting", "Usuwanie...") : t("common.delete", "Usuń")}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/user-application/src/components/sources/delete-source-dialog.tsx
+++ b/apps/user-application/src/components/sources/delete-source-dialog.tsx
@@ -1,0 +1,73 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+	DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteMyNotificationSource } from "@/core/functions/notification-sources";
+import { useTranslation } from "react-i18next";
+
+export function DeleteSourceDialog({
+	sourceId,
+	sourceName,
+}: {
+	sourceId: number;
+	sourceName: string;
+}) {
+	const { t } = useTranslation();
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: () => deleteMyNotificationSource({ data: { id: sourceId } }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["notification-sources"] });
+		},
+	});
+
+	return (
+		<Dialog>
+			<DialogTrigger asChild>
+				<Button variant="ghost" size="sm">
+					<Trash2 className="h-4 w-4 text-destructive" />
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						{t("sources.deleteTitle", "Usuń źródło")}
+					</DialogTitle>
+					<DialogDescription>
+						{t(
+							"sources.deleteDescription",
+							'Czy na pewno chcesz usunąć "{{name}}"? Tej operacji nie można cofnąć.',
+							{ name: sourceName },
+						)}
+					</DialogDescription>
+				</DialogHeader>
+				<DialogFooter>
+					<DialogClose asChild>
+						<Button variant="outline">
+							{t("common.cancel", "Anuluj")}
+						</Button>
+					</DialogClose>
+					<Button
+						variant="destructive"
+						onClick={() => mutation.mutate()}
+						disabled={mutation.isPending}
+					>
+						{mutation.isPending
+							? t("common.deleting", "Usuwanie...")
+							: t("common.delete", "Usuń")}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/user-application/src/components/sources/source-form.tsx
+++ b/apps/user-application/src/components/sources/source-form.tsx
@@ -94,9 +94,7 @@ export function SourceForm({ mode, initialData }: SourceFormProps) {
 		setErrors({});
 
 		const config = buildConfig();
-		const alertHours = alertBeforeHours
-			? Number(alertBeforeHours)
-			: undefined;
+		const alertHours = alertBeforeHours ? Number(alertBeforeHours) : undefined;
 
 		const input = { name, type, config, alertBeforeHours: alertHours };
 		const parsed = SourceFormInput.safeParse(input);
@@ -157,9 +155,7 @@ export function SourceForm({ mode, initialData }: SourceFormProps) {
 							placeholder={t("sources.namePlaceholder", "np. Wywóz — ul. Kwiatowa")}
 							aria-invalid={!!errors.name}
 						/>
-						{errors.name && (
-							<p className="text-sm text-destructive mt-1">{errors.name}</p>
-						)}
+						{errors.name && <p className="text-sm text-destructive mt-1">{errors.name}</p>}
 					</div>
 
 					{mode === "create" && (
@@ -177,9 +173,7 @@ export function SourceForm({ mode, initialData }: SourceFormProps) {
 									))}
 								</SelectContent>
 							</Select>
-							{errors.type && (
-								<p className="text-sm text-destructive mt-1">{errors.type}</p>
-							)}
+							{errors.type && <p className="text-sm text-destructive mt-1">{errors.type}</p>}
 						</div>
 					)}
 
@@ -215,16 +209,12 @@ export function SourceForm({ mode, initialData }: SourceFormProps) {
 								aria-invalid={!!errors.alertBeforeHours}
 							/>
 							{errors.alertBeforeHours && (
-								<p className="text-sm text-destructive mt-1">
-									{errors.alertBeforeHours}
-								</p>
+								<p className="text-sm text-destructive mt-1">{errors.alertBeforeHours}</p>
 							)}
 						</div>
 					)}
 
-					{errors._form && (
-						<p className="text-sm text-destructive">{errors._form}</p>
-					)}
+					{errors._form && <p className="text-sm text-destructive">{errors._form}</p>}
 
 					{(createMutation.error || updateMutation.error) && (
 						<p className="text-sm text-destructive">

--- a/apps/user-application/src/components/sources/source-form.tsx
+++ b/apps/user-application/src/components/sources/source-form.tsx
@@ -1,0 +1,255 @@
+import * as React from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { useTranslation } from "react-i18next";
+import {
+	createMyNotificationSource,
+	updateMyNotificationSource,
+} from "@/core/functions/notification-sources";
+import {
+	SourceFormInput,
+	SOURCE_TYPES,
+	getAlertBeforeHoursDefault,
+} from "@repo/data-ops/zod-schema/source-form-schema";
+import { WasteConfigFields } from "./waste-config-fields";
+import { BirthdayConfigFields } from "./birthday-config-fields";
+
+interface SourceFormProps {
+	mode: "create" | "edit";
+	initialData?: {
+		id: number;
+		name: string;
+		type: string;
+		config: Record<string, any>;
+		alertBeforeHours: number | null;
+	};
+}
+
+export function SourceForm({ mode, initialData }: SourceFormProps) {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	const [name, setName] = React.useState(initialData?.name ?? "");
+	const [type, setType] = React.useState(initialData?.type ?? "");
+	const [alertBeforeHours, setAlertBeforeHours] = React.useState<string>(
+		initialData?.alertBeforeHours?.toString() ?? "",
+	);
+	const [errors, setErrors] = React.useState<Record<string, string>>({});
+
+	// Waste collection config state
+	const [wasteAddress, setWasteAddress] = React.useState(
+		(initialData?.config as any)?.address ?? "",
+	);
+	const [wasteSchedule, setWasteSchedule] = React.useState(
+		(initialData?.config as any)?.schedule ?? [{ type: "", dates: [""] }],
+	);
+
+	// Birthday config state
+	const [birthdays, setBirthdays] = React.useState(
+		(initialData?.config as any)?.birthdays ?? [{ name: "", date: "" }],
+	);
+
+	const createMutation = useMutation({
+		mutationFn: createMyNotificationSource,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["notification-sources"] });
+			navigate({ to: "/app/sources" });
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: updateMyNotificationSource,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["notification-sources"] });
+			navigate({ to: "/app/sources" });
+		},
+	});
+
+	const isPending = createMutation.isPending || updateMutation.isPending;
+
+	const buildConfig = () => {
+		if (type === "waste_collection") {
+			return { address: wasteAddress, schedule: wasteSchedule };
+		}
+		if (type === "birthday") {
+			return { birthdays };
+		}
+		return {};
+	};
+
+	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		setErrors({});
+
+		const config = buildConfig();
+		const alertHours = alertBeforeHours
+			? Number(alertBeforeHours)
+			: undefined;
+
+		const input = { name, type, config, alertBeforeHours: alertHours };
+		const parsed = SourceFormInput.safeParse(input);
+
+		if (!parsed.success) {
+			const flat = parsed.error.flatten();
+			const fieldErrors: Record<string, string> = {};
+			for (const [key, msgs] of Object.entries(flat.fieldErrors)) {
+				const first = msgs?.[0];
+				if (first) fieldErrors[key] = first;
+			}
+			const formErr = flat.formErrors[0];
+			if (formErr) fieldErrors._form = formErr;
+			setErrors(fieldErrors);
+			return;
+		}
+
+		if (mode === "create") {
+			createMutation.mutate({ data: parsed.data });
+		} else if (initialData) {
+			updateMutation.mutate({
+				data: {
+					id: initialData.id,
+					data: {
+						name: parsed.data.name,
+						config: parsed.data.config,
+						alertBeforeHours: alertHours,
+					},
+				},
+			});
+		}
+	};
+
+	const handleTypeChange = (newType: string) => {
+		setType(newType);
+		if (!alertBeforeHours) {
+			setAlertBeforeHours(String(getAlertBeforeHoursDefault(newType)));
+		}
+	};
+
+	return (
+		<Card className="max-w-2xl mx-auto">
+			<CardHeader>
+				<CardTitle>
+					{mode === "create"
+						? t("sources.createTitle", "Nowe źródło powiadomień")
+						: t("sources.editTitle", "Edytuj źródło")}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onSubmit={handleSubmit} className="space-y-6">
+					<div>
+						<Label htmlFor="name">{t("sources.name", "Nazwa")}</Label>
+						<Input
+							id="name"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder={t("sources.namePlaceholder", "np. Wywóz — ul. Kwiatowa")}
+							aria-invalid={!!errors.name}
+						/>
+						{errors.name && (
+							<p className="text-sm text-destructive mt-1">{errors.name}</p>
+						)}
+					</div>
+
+					{mode === "create" && (
+						<div>
+							<Label>{t("sources.type", "Typ")}</Label>
+							<Select value={type} onValueChange={handleTypeChange}>
+								<SelectTrigger>
+									<SelectValue placeholder={t("sources.selectType", "Wybierz typ")} />
+								</SelectTrigger>
+								<SelectContent>
+									{SOURCE_TYPES.map((st) => (
+										<SelectItem key={st.value} value={st.value}>
+											{st.icon} {st.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+							{errors.type && (
+								<p className="text-sm text-destructive mt-1">{errors.type}</p>
+							)}
+						</div>
+					)}
+
+					{type === "waste_collection" && (
+						<WasteConfigFields
+							address={wasteAddress}
+							schedule={wasteSchedule}
+							onAddressChange={setWasteAddress}
+							onScheduleChange={setWasteSchedule}
+							errors={errors}
+						/>
+					)}
+
+					{type === "birthday" && (
+						<BirthdayConfigFields
+							birthdays={birthdays}
+							onBirthdaysChange={setBirthdays}
+							errors={errors}
+						/>
+					)}
+
+					{type && (
+						<div>
+							<Label htmlFor="alertBeforeHours">
+								{t("sources.alertBeforeHours", "Alert przed (godziny)")}
+							</Label>
+							<Input
+								id="alertBeforeHours"
+								type="number"
+								min="1"
+								value={alertBeforeHours}
+								onChange={(e) => setAlertBeforeHours(e.target.value)}
+								aria-invalid={!!errors.alertBeforeHours}
+							/>
+							{errors.alertBeforeHours && (
+								<p className="text-sm text-destructive mt-1">
+									{errors.alertBeforeHours}
+								</p>
+							)}
+						</div>
+					)}
+
+					{errors._form && (
+						<p className="text-sm text-destructive">{errors._form}</p>
+					)}
+
+					{(createMutation.error || updateMutation.error) && (
+						<p className="text-sm text-destructive">
+							{(createMutation.error || updateMutation.error)?.message}
+						</p>
+					)}
+
+					<div className="flex gap-3 justify-end">
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => navigate({ to: "/app/sources" })}
+						>
+							{t("common.cancel", "Anuluj")}
+						</Button>
+						<Button type="submit" disabled={isPending || !type}>
+							{isPending
+								? t("common.saving", "Zapisywanie...")
+								: mode === "create"
+									? t("sources.create", "Utwórz")
+									: t("sources.save", "Zapisz")}
+						</Button>
+					</div>
+				</form>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/user-application/src/components/sources/source-list.tsx
+++ b/apps/user-application/src/components/sources/source-list.tsx
@@ -84,11 +84,7 @@ export function SourceList({ sources }: { sources: SourceItem[] }) {
 									</Badge>
 									{source.lastDelivery && (
 										<Badge
-											variant={
-												source.lastDelivery.status === "success"
-													? "outline"
-													: "destructive"
-											}
+											variant={source.lastDelivery.status === "success" ? "outline" : "destructive"}
 										>
 											{source.lastDelivery.status === "success"
 												? t("sources.delivered", "Wysłane")
@@ -110,7 +106,10 @@ export function SourceList({ sources }: { sources: SourceItem[] }) {
 									</div>
 									<div className="flex gap-2">
 										<Button variant="ghost" size="sm" asChild>
-											<Link to="/app/sources/$sourceId/edit" params={{ sourceId: String(source.id) }}>
+											<Link
+												to="/app/sources/$sourceId/edit"
+												params={{ sourceId: String(source.id) }}
+											>
 												<Pencil className="h-4 w-4" />
 											</Link>
 										</Button>

--- a/apps/user-application/src/components/sources/source-list.tsx
+++ b/apps/user-application/src/components/sources/source-list.tsx
@@ -1,0 +1,127 @@
+import { Link } from "@tanstack/react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Plus, Pencil } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { DeleteSourceDialog } from "./delete-source-dialog";
+
+const TYPE_ICONS: Record<string, string> = {
+	waste_collection: "🗑",
+	birthday: "🎂",
+};
+
+const TYPE_LABELS: Record<string, string> = {
+	waste_collection: "Wywóz śmieci",
+	birthday: "Urodziny",
+};
+
+interface SourceItem {
+	id: number;
+	name: string;
+	type: string;
+	enabled: boolean;
+	alertBeforeHours: number | null;
+	lastDelivery: {
+		status: string;
+		error: string | null;
+		createdAt: Date;
+	} | null;
+}
+
+export function SourceList({ sources }: { sources: SourceItem[] }) {
+	const { t } = useTranslation();
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center justify-between">
+				<h2 className="text-2xl font-bold tracking-tight">
+					{t("sources.title", "Źródła powiadomień")}
+				</h2>
+				<Button asChild>
+					<Link to="/app/sources/new">
+						<Plus className="mr-2 h-4 w-4" />
+						{t("sources.add", "Dodaj źródło")}
+					</Link>
+				</Button>
+			</div>
+
+			{sources.length === 0 ? (
+				<Card>
+					<CardContent className="flex flex-col items-center justify-center py-12">
+						<p className="text-muted-foreground mb-4">
+							{t("sources.empty", "Nie masz jeszcze żadnych źródeł powiadomień.")}
+						</p>
+						<Button asChild>
+							<Link to="/app/sources/new">
+								<Plus className="mr-2 h-4 w-4" />
+								{t("sources.addFirst", "Dodaj pierwsze źródło")}
+							</Link>
+						</Button>
+					</CardContent>
+				</Card>
+			) : (
+				<div className="grid gap-4">
+					{sources.map((source) => (
+						<Card key={source.id} className="group">
+							<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+								<div className="flex items-center gap-3">
+									<span className="text-2xl" role="img" aria-label={source.type}>
+										{TYPE_ICONS[source.type] ?? "📌"}
+									</span>
+									<div>
+										<CardTitle className="text-lg">{source.name}</CardTitle>
+										<p className="text-sm text-muted-foreground">
+											{TYPE_LABELS[source.type] ?? source.type}
+										</p>
+									</div>
+								</div>
+								<div className="flex items-center gap-2">
+									<Badge variant={source.enabled ? "default" : "secondary"}>
+										{source.enabled
+											? t("sources.enabled", "Aktywne")
+											: t("sources.disabled", "Wyłączone")}
+									</Badge>
+									{source.lastDelivery && (
+										<Badge
+											variant={
+												source.lastDelivery.status === "success"
+													? "outline"
+													: "destructive"
+											}
+										>
+											{source.lastDelivery.status === "success"
+												? t("sources.delivered", "Wysłane")
+												: t("sources.failed", "Błąd")}
+										</Badge>
+									)}
+								</div>
+							</CardHeader>
+							<CardContent>
+								<div className="flex items-center justify-between">
+									<div className="text-sm text-muted-foreground">
+										{source.alertBeforeHours && (
+											<span>
+												{t("sources.alertBefore", "Alert: {{hours}}h przed", {
+													hours: source.alertBeforeHours,
+												})}
+											</span>
+										)}
+									</div>
+									<div className="flex gap-2">
+										<Button variant="ghost" size="sm" asChild>
+											<Link to="/app/sources/$sourceId/edit" params={{ sourceId: String(source.id) }}>
+												<Pencil className="h-4 w-4" />
+											</Link>
+										</Button>
+										<DeleteSourceDialog sourceId={source.id} sourceName={source.name} />
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/user-application/src/components/sources/waste-config-fields.tsx
+++ b/apps/user-application/src/components/sources/waste-config-fields.tsx
@@ -45,27 +45,21 @@ export function WasteConfigFields({
 			.split(",")
 			.map((d) => d.trim())
 			.filter(Boolean);
-		const updated = schedule.map((entry, i) =>
-			i === index ? { type: entry.type, dates } : entry,
-		);
+		const updated = schedule.map((entry, i) => (i === index ? { type: entry.type, dates } : entry));
 		onScheduleChange(updated);
 	};
 
 	return (
 		<div className="space-y-4">
 			<div>
-				<Label htmlFor="address">
-					{t("sources.waste.address", "Adres")}
-				</Label>
+				<Label htmlFor="address">{t("sources.waste.address", "Adres")}</Label>
 				<Input
 					id="address"
 					value={address}
 					onChange={(e) => onAddressChange(e.target.value)}
 					placeholder="ul. Kwiatowa 5"
 				/>
-				{errors?.address && (
-					<p className="text-sm text-destructive mt-1">{errors.address}</p>
-				)}
+				{errors?.address && <p className="text-sm text-destructive mt-1">{errors.address}</p>}
 			</div>
 
 			<div className="space-y-3">
@@ -93,19 +87,12 @@ export function WasteConfigFields({
 								placeholder="2026-04-15, 2026-05-15"
 							/>
 						</div>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							onClick={() => removeEntry(index)}
-						>
+						<Button type="button" variant="ghost" size="sm" onClick={() => removeEntry(index)}>
 							<X className="h-4 w-4" />
 						</Button>
 					</div>
 				))}
-				{errors?.schedule && (
-					<p className="text-sm text-destructive">{errors.schedule}</p>
-				)}
+				{errors?.schedule && <p className="text-sm text-destructive">{errors.schedule}</p>}
 			</div>
 		</div>
 	);

--- a/apps/user-application/src/components/sources/waste-config-fields.tsx
+++ b/apps/user-application/src/components/sources/waste-config-fields.tsx
@@ -1,0 +1,112 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Plus, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+interface WasteScheduleEntry {
+	type: string;
+	dates: string[];
+}
+
+interface WasteConfigFieldsProps {
+	address: string;
+	schedule: WasteScheduleEntry[];
+	onAddressChange: (address: string) => void;
+	onScheduleChange: (schedule: WasteScheduleEntry[]) => void;
+	errors?: Record<string, string>;
+}
+
+export function WasteConfigFields({
+	address,
+	schedule,
+	onAddressChange,
+	onScheduleChange,
+	errors,
+}: WasteConfigFieldsProps) {
+	const { t } = useTranslation();
+
+	const addEntry = () => {
+		onScheduleChange([...schedule, { type: "", dates: [""] }]);
+	};
+
+	const removeEntry = (index: number) => {
+		onScheduleChange(schedule.filter((_, i) => i !== index));
+	};
+
+	const updateEntryType = (index: number, newType: string) => {
+		const updated = schedule.map((entry, i) =>
+			i === index ? { type: newType, dates: entry.dates } : entry,
+		);
+		onScheduleChange(updated);
+	};
+
+	const updateEntryDates = (index: number, datesStr: string) => {
+		const dates = datesStr
+			.split(",")
+			.map((d) => d.trim())
+			.filter(Boolean);
+		const updated = schedule.map((entry, i) =>
+			i === index ? { type: entry.type, dates } : entry,
+		);
+		onScheduleChange(updated);
+	};
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<Label htmlFor="address">
+					{t("sources.waste.address", "Adres")}
+				</Label>
+				<Input
+					id="address"
+					value={address}
+					onChange={(e) => onAddressChange(e.target.value)}
+					placeholder="ul. Kwiatowa 5"
+				/>
+				{errors?.address && (
+					<p className="text-sm text-destructive mt-1">{errors.address}</p>
+				)}
+			</div>
+
+			<div className="space-y-3">
+				<div className="flex items-center justify-between">
+					<Label>{t("sources.waste.schedule", "Harmonogram")}</Label>
+					<Button type="button" variant="outline" size="sm" onClick={addEntry}>
+						<Plus className="h-4 w-4 mr-1" />
+						{t("sources.waste.addEntry", "Dodaj typ")}
+					</Button>
+				</div>
+
+				{schedule.map((entry, index) => (
+					<div key={index} className="flex gap-2 items-start">
+						<div className="flex-1">
+							<Input
+								value={entry.type}
+								onChange={(e) => updateEntryType(index, e.target.value)}
+								placeholder={t("sources.waste.wasteType", "Typ (np. szkło)")}
+							/>
+						</div>
+						<div className="flex-[2]">
+							<Input
+								value={entry.dates.join(", ")}
+								onChange={(e) => updateEntryDates(index, e.target.value)}
+								placeholder="2026-04-15, 2026-05-15"
+							/>
+						</div>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => removeEntry(index)}
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					</div>
+				))}
+				{errors?.schedule && (
+					<p className="text-sm text-destructive">{errors.schedule}</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/user-application/src/core/functions/notification-sources.ts
+++ b/apps/user-application/src/core/functions/notification-sources.ts
@@ -9,7 +9,10 @@ import {
 	createNotificationSource,
 } from "@repo/data-ops/queries/notification-sources";
 import { getLatestDeliveryBySourceIds } from "@repo/data-ops/queries/delivery";
-import { SourceFormInput, getAlertBeforeHoursDefault } from "@repo/data-ops/zod-schema/source-form-schema";
+import {
+	SourceFormInput,
+	getAlertBeforeHoursDefault,
+} from "@repo/data-ops/zod-schema/source-form-schema";
 import { UpdateNotificationSourceInput } from "@repo/data-ops/zod-schema/notification-source";
 import { z } from "zod";
 

--- a/apps/user-application/src/core/functions/notification-sources.ts
+++ b/apps/user-application/src/core/functions/notification-sources.ts
@@ -1,0 +1,79 @@
+import { createServerFn } from "@tanstack/react-start";
+import { protectedFunctionMiddleware } from "@/core/middleware/auth";
+import { getHousehold } from "@repo/data-ops/queries/household";
+import {
+	getNotificationSources,
+	getNotificationSourceById,
+	updateNotificationSource,
+	deleteNotificationSource,
+	createNotificationSource,
+} from "@repo/data-ops/queries/notification-sources";
+import { getLatestDeliveryBySourceIds } from "@repo/data-ops/queries/delivery";
+import { SourceFormInput, getAlertBeforeHoursDefault } from "@repo/data-ops/zod-schema/source-form-schema";
+import { UpdateNotificationSourceInput } from "@repo/data-ops/zod-schema/notification-source";
+import { z } from "zod";
+
+const baseFunction = createServerFn().middleware([protectedFunctionMiddleware]);
+
+export const getMyNotificationSources = baseFunction.handler(async () => {
+	const household = await getHousehold();
+	if (!household) throw new Error("No household found");
+
+	const sources = await getNotificationSources(household.id);
+	const sourceIds = sources.map((s) => s.id);
+	const deliveryMap = await getLatestDeliveryBySourceIds(sourceIds);
+
+	return sources.map((source) => ({
+		...source,
+		config: source.config as Record<string, any>,
+		lastDelivery: deliveryMap.get(source.id) ?? null,
+	}));
+});
+
+export const getNotificationSource = baseFunction
+	.inputValidator((data) => z.object({ id: z.number() }).parse(data))
+	.handler(async (ctx) => {
+		const source = await getNotificationSourceById(ctx.data.id);
+		if (!source) return undefined;
+		return { ...source, config: source.config as Record<string, any> };
+	});
+
+export const createMyNotificationSource = baseFunction
+	.inputValidator((data) => SourceFormInput.parse(data))
+	.handler(async (ctx) => {
+		const household = await getHousehold();
+		if (!household) throw new Error("No household found");
+
+		const { name, type, config, alertBeforeHours } = ctx.data;
+		const effectiveAlertHours = alertBeforeHours ?? getAlertBeforeHoursDefault(type);
+
+		const source = await createNotificationSource({
+			householdId: household.id,
+			name,
+			type,
+			config,
+			alertBeforeHours: effectiveAlertHours,
+		});
+
+		return { ...source, config: source.config as Record<string, any> };
+	});
+
+const UpdateInput = z.object({
+	id: z.number(),
+	data: UpdateNotificationSourceInput,
+});
+
+export const updateMyNotificationSource = baseFunction
+	.inputValidator((data) => UpdateInput.parse(data))
+	.handler(async (ctx) => {
+		const updated = await updateNotificationSource(ctx.data.id, ctx.data.data);
+		if (!updated) throw new Error("Source not found");
+		return { ...updated, config: updated.config as Record<string, any> };
+	});
+
+export const deleteMyNotificationSource = baseFunction
+	.inputValidator((data) => z.object({ id: z.number() }).parse(data))
+	.handler(async (ctx) => {
+		await deleteNotificationSource(ctx.data.id);
+		return { success: true };
+	});

--- a/apps/user-application/src/locales/en.json
+++ b/apps/user-application/src/locales/en.json
@@ -3,7 +3,10 @@
 		"cancel": "Cancel",
 		"confirm": "Confirm",
 		"save": "Save",
-		"close": "Close"
+		"close": "Close",
+		"saving": "Saving...",
+		"delete": "Delete",
+		"deleting": "Deleting..."
 	},
 	"nav": {
 		"appName": "Waste Alerts",
@@ -13,7 +16,8 @@
 		"documentation": "Documentation",
 		"signIn": "Sign In",
 		"signOut": "Sign Out",
-		"account": "Account"
+		"account": "Account",
+		"sources": "Sources"
 	},
 	"theme": {
 		"toggle": "Toggle theme",
@@ -121,6 +125,39 @@
 				"title": "Setup Complete",
 				"smsEnabled": "SMS notifications enabled"
 			}
+		}
+	},
+	"sources": {
+		"title": "Notification Sources",
+		"add": "Add source",
+		"addFirst": "Add first source",
+		"empty": "You don't have any notification sources yet.",
+		"enabled": "Active",
+		"disabled": "Disabled",
+		"delivered": "Delivered",
+		"failed": "Failed",
+		"alertBefore": "Alert: {{hours}}h before",
+		"createTitle": "New notification source",
+		"editTitle": "Edit source",
+		"name": "Name",
+		"namePlaceholder": "e.g. Waste — Kwiatowa St.",
+		"type": "Type",
+		"selectType": "Select type",
+		"alertBeforeHours": "Alert before (hours)",
+		"create": "Create",
+		"save": "Save",
+		"deleteTitle": "Delete source",
+		"deleteDescription": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone.",
+		"waste": {
+			"address": "Address",
+			"schedule": "Schedule",
+			"addEntry": "Add type",
+			"wasteType": "Type (e.g. glass)"
+		},
+		"birthday": {
+			"list": "Birthday list",
+			"add": "Add person",
+			"name": "Name"
 		}
 	},
 	"phone": {

--- a/apps/user-application/src/locales/pl.json
+++ b/apps/user-application/src/locales/pl.json
@@ -3,7 +3,10 @@
 		"cancel": "Anuluj",
 		"confirm": "Potwierdź",
 		"save": "Zapisz",
-		"close": "Zamknij"
+		"close": "Zamknij",
+		"saving": "Zapisywanie...",
+		"delete": "Usuń",
+		"deleting": "Usuwanie..."
 	},
 	"nav": {
 		"appName": "powiadomienia.info - wywóz śmieci",
@@ -13,7 +16,8 @@
 		"documentation": "Dokumentacja",
 		"signIn": "Zaloguj się",
 		"signOut": "Wyloguj się",
-		"account": "Konto"
+		"account": "Konto",
+		"sources": "Źródła"
 	},
 	"theme": {
 		"toggle": "Zmień motyw",
@@ -121,6 +125,39 @@
 				"title": "Konfiguracja Zakończona",
 				"smsEnabled": "Powiadomienia SMS włączone"
 			}
+		}
+	},
+	"sources": {
+		"title": "Źródła powiadomień",
+		"add": "Dodaj źródło",
+		"addFirst": "Dodaj pierwsze źródło",
+		"empty": "Nie masz jeszcze żadnych źródeł powiadomień.",
+		"enabled": "Aktywne",
+		"disabled": "Wyłączone",
+		"delivered": "Wysłane",
+		"failed": "Błąd",
+		"alertBefore": "Alert: {{hours}}h przed",
+		"createTitle": "Nowe źródło powiadomień",
+		"editTitle": "Edytuj źródło",
+		"name": "Nazwa",
+		"namePlaceholder": "np. Wywóz — ul. Kwiatowa",
+		"type": "Typ",
+		"selectType": "Wybierz typ",
+		"alertBeforeHours": "Alert przed (godziny)",
+		"create": "Utwórz",
+		"save": "Zapisz",
+		"deleteTitle": "Usuń źródło",
+		"deleteDescription": "Czy na pewno chcesz usunąć \"{{name}}\"? Tej operacji nie można cofnąć.",
+		"waste": {
+			"address": "Adres",
+			"schedule": "Harmonogram",
+			"addEntry": "Dodaj typ",
+			"wasteType": "Typ (np. szkło)"
+		},
+		"birthday": {
+			"list": "Lista urodzin",
+			"add": "Dodaj osobę",
+			"name": "Imię"
 		}
 	},
 	"phone": {

--- a/apps/user-application/src/routeTree.gen.ts
+++ b/apps/user-application/src/routeTree.gen.ts
@@ -20,6 +20,9 @@ import { Route as AuthLoginRouteImport } from './routes/auth/login'
 import { Route as AuthAppIndexRouteImport } from './routes/_auth/app/index'
 import { Route as ApiUserHasCredentialAccountRouteImport } from './routes/api/user/has-credential-account'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth.$'
+import { Route as AuthAppSourcesIndexRouteImport } from './routes/_auth/app/sources/index'
+import { Route as AuthAppSourcesNewRouteImport } from './routes/_auth/app/sources/new'
+import { Route as AuthAppSourcesSourceIdEditRouteImport } from './routes/_auth/app/sources/$sourceId.edit'
 
 const TermsOfServiceRoute = TermsOfServiceRouteImport.update({
   id: '/terms-of-service',
@@ -76,6 +79,22 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthAppSourcesIndexRoute = AuthAppSourcesIndexRouteImport.update({
+  id: '/app/sources/',
+  path: '/app/sources/',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthAppSourcesNewRoute = AuthAppSourcesNewRouteImport.update({
+  id: '/app/sources/new',
+  path: '/app/sources/new',
+  getParentRoute: () => AuthRouteRoute,
+} as any)
+const AuthAppSourcesSourceIdEditRoute =
+  AuthAppSourcesSourceIdEditRouteImport.update({
+    id: '/app/sources/$sourceId/edit',
+    path: '/app/sources/$sourceId/edit',
+    getParentRoute: () => AuthRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -87,7 +106,10 @@ export interface FileRoutesByFullPath {
   '/auth/register': typeof AuthRegisterRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/user/has-credential-account': typeof ApiUserHasCredentialAccountRoute
-  '/app': typeof AuthAppIndexRoute
+  '/app/': typeof AuthAppIndexRoute
+  '/app/sources/new': typeof AuthAppSourcesNewRoute
+  '/app/sources/': typeof AuthAppSourcesIndexRoute
+  '/app/sources/$sourceId/edit': typeof AuthAppSourcesSourceIdEditRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -100,6 +122,9 @@ export interface FileRoutesByTo {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/user/has-credential-account': typeof ApiUserHasCredentialAccountRoute
   '/app': typeof AuthAppIndexRoute
+  '/app/sources/new': typeof AuthAppSourcesNewRoute
+  '/app/sources': typeof AuthAppSourcesIndexRoute
+  '/app/sources/$sourceId/edit': typeof AuthAppSourcesSourceIdEditRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -114,6 +139,9 @@ export interface FileRoutesById {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/user/has-credential-account': typeof ApiUserHasCredentialAccountRoute
   '/_auth/app/': typeof AuthAppIndexRoute
+  '/_auth/app/sources/new': typeof AuthAppSourcesNewRoute
+  '/_auth/app/sources/': typeof AuthAppSourcesIndexRoute
+  '/_auth/app/sources/$sourceId/edit': typeof AuthAppSourcesSourceIdEditRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -127,7 +155,10 @@ export interface FileRouteTypes {
     | '/auth/register'
     | '/api/auth/$'
     | '/api/user/has-credential-account'
-    | '/app'
+    | '/app/'
+    | '/app/sources/new'
+    | '/app/sources/'
+    | '/app/sources/$sourceId/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -140,6 +171,9 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/user/has-credential-account'
     | '/app'
+    | '/app/sources/new'
+    | '/app/sources'
+    | '/app/sources/$sourceId/edit'
   id:
     | '__root__'
     | '/'
@@ -153,6 +187,9 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/user/has-credential-account'
     | '/_auth/app/'
+    | '/_auth/app/sources/new'
+    | '/_auth/app/sources/'
+    | '/_auth/app/sources/$sourceId/edit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -201,7 +238,7 @@ declare module '@tanstack/react-router' {
     '/_auth': {
       id: '/_auth'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -229,7 +266,7 @@ declare module '@tanstack/react-router' {
     '/_auth/app/': {
       id: '/_auth/app/'
       path: '/app'
-      fullPath: '/app'
+      fullPath: '/app/'
       preLoaderRoute: typeof AuthAppIndexRouteImport
       parentRoute: typeof AuthRouteRoute
     }
@@ -247,15 +284,42 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_auth/app/sources/': {
+      id: '/_auth/app/sources/'
+      path: '/app/sources'
+      fullPath: '/app/sources/'
+      preLoaderRoute: typeof AuthAppSourcesIndexRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/app/sources/new': {
+      id: '/_auth/app/sources/new'
+      path: '/app/sources/new'
+      fullPath: '/app/sources/new'
+      preLoaderRoute: typeof AuthAppSourcesNewRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
+    '/_auth/app/sources/$sourceId/edit': {
+      id: '/_auth/app/sources/$sourceId/edit'
+      path: '/app/sources/$sourceId/edit'
+      fullPath: '/app/sources/$sourceId/edit'
+      preLoaderRoute: typeof AuthAppSourcesSourceIdEditRouteImport
+      parentRoute: typeof AuthRouteRoute
+    }
   }
 }
 
 interface AuthRouteRouteChildren {
   AuthAppIndexRoute: typeof AuthAppIndexRoute
+  AuthAppSourcesNewRoute: typeof AuthAppSourcesNewRoute
+  AuthAppSourcesIndexRoute: typeof AuthAppSourcesIndexRoute
+  AuthAppSourcesSourceIdEditRoute: typeof AuthAppSourcesSourceIdEditRoute
 }
 
 const AuthRouteRouteChildren: AuthRouteRouteChildren = {
   AuthAppIndexRoute: AuthAppIndexRoute,
+  AuthAppSourcesNewRoute: AuthAppSourcesNewRoute,
+  AuthAppSourcesIndexRoute: AuthAppSourcesIndexRoute,
+  AuthAppSourcesSourceIdEditRoute: AuthAppSourcesSourceIdEditRoute,
 }
 
 const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
@@ -277,13 +341,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.tsx'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/apps/user-application/src/routes/_auth/app/sources/$sourceId.edit.tsx
+++ b/apps/user-application/src/routes/_auth/app/sources/$sourceId.edit.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getNotificationSource } from "@/core/functions/notification-sources";
+import { DashboardNav } from "@/components/navigation/dashboard-nav";
+import { Footer } from "@/components/landing/footer";
+import { SourceForm } from "@/components/sources/source-form";
+
+export const Route = createFileRoute("/_auth/app/sources/$sourceId/edit")({
+	component: EditSourcePage,
+	loader: async ({ params, context: { queryClient } }) => {
+		const sourceId = Number(params.sourceId);
+		await queryClient.prefetchQuery({
+			queryKey: ["notification-source", sourceId],
+			queryFn: () => getNotificationSource({ data: { id: sourceId } }),
+		});
+	},
+});
+
+function EditSourcePage() {
+	const { sourceId } = Route.useParams();
+	const id = Number(sourceId);
+
+	const { data: source } = useSuspenseQuery({
+		queryKey: ["notification-source", id],
+		queryFn: () => getNotificationSource({ data: { id } }),
+	});
+
+	if (!source) {
+		return <div>Source not found</div>;
+	}
+
+	return (
+		<div className="min-h-dvh flex flex-col bg-background">
+			<DashboardNav />
+			<section className="flex-1 relative px-6 lg:px-8 pt-32 pb-8">
+				<div className="mx-auto max-w-4xl">
+					<SourceForm
+						mode="edit"
+						initialData={{
+							id: source.id,
+							name: source.name,
+							type: source.type,
+							config: source.config as Record<string, any>,
+							alertBeforeHours: source.alertBeforeHours,
+						}}
+					/>
+				</div>
+			</section>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/user-application/src/routes/_auth/app/sources/index.tsx
+++ b/apps/user-application/src/routes/_auth/app/sources/index.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getMyNotificationSources } from "@/core/functions/notification-sources";
+import { DashboardNav } from "@/components/navigation/dashboard-nav";
+import { Footer } from "@/components/landing/footer";
+import { SourceList } from "@/components/sources/source-list";
+
+export const Route = createFileRoute("/_auth/app/sources/")({
+	component: SourcesPage,
+	loader: async ({ context: { queryClient } }) => {
+		await queryClient.prefetchQuery({
+			queryKey: ["notification-sources"],
+			queryFn: () => getMyNotificationSources(),
+		});
+	},
+});
+
+function SourcesPage() {
+	const { data: sources } = useSuspenseQuery({
+		queryKey: ["notification-sources"],
+		queryFn: () => getMyNotificationSources(),
+	});
+
+	return (
+		<div className="min-h-dvh flex flex-col bg-background">
+			<DashboardNav />
+			<section className="flex-1 relative px-6 lg:px-8 pt-32 pb-8">
+				<div className="mx-auto max-w-4xl">
+					<SourceList sources={sources ?? []} />
+				</div>
+			</section>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/user-application/src/routes/_auth/app/sources/new.tsx
+++ b/apps/user-application/src/routes/_auth/app/sources/new.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { DashboardNav } from "@/components/navigation/dashboard-nav";
+import { Footer } from "@/components/landing/footer";
+import { SourceForm } from "@/components/sources/source-form";
+
+export const Route = createFileRoute("/_auth/app/sources/new")({
+	component: NewSourcePage,
+});
+
+function NewSourcePage() {
+	return (
+		<div className="min-h-dvh flex flex-col bg-background">
+			<DashboardNav />
+			<section className="flex-1 relative px-6 lg:px-8 pt-32 pb-8">
+				<div className="mx-auto max-w-4xl">
+					<SourceForm mode="create" />
+				</div>
+			</section>
+			<Footer />
+		</div>
+	);
+}

--- a/packages/data-ops/src/drizzle/migrations/dev/0017_exotic_shaman.sql
+++ b/packages/data-ops/src/drizzle/migrations/dev/0017_exotic_shaman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "notification_sources" ADD COLUMN "alert_before_hours" integer;

--- a/packages/data-ops/src/drizzle/migrations/dev/meta/0017_snapshot.json
+++ b/packages/data-ops/src/drizzle/migrations/dev/meta/0017_snapshot.json
@@ -1,0 +1,1022 @@
+{
+  "id": "46cf9d4a-e175-4ecc-8184-fa0d2875e50d",
+  "prevId": "eee7dcda-1ea4-42c5-9eb9-af3049dd9a08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_account_userId_idx": {
+          "name": "auth_account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_session_userId_idx": {
+          "name": "auth_session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_session_token_unique": {
+          "name": "auth_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pl'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_user_email_unique": {
+          "name": "auth_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verification_identifier_idx": {
+          "name": "auth_verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channels_household_id_idx": {
+          "name": "channels_household_id_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channels_household_id_households_id_fk": {
+          "name": "channels_household_id_households_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_failures": {
+      "name": "delivery_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "df_source_id_idx": {
+          "name": "df_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "df_created_at_idx": {
+          "name": "df_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_failures_source_id_notification_sources_id_fk": {
+          "name": "delivery_failures_source_id_notification_sources_id_fk",
+          "tableFrom": "delivery_failures",
+          "tableTo": "notification_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_log": {
+      "name": "delivery_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dl_source_id_idx": {
+          "name": "dl_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dl_status_idx": {
+          "name": "dl_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dl_created_at_idx": {
+          "name": "dl_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "delivery_log_source_id_notification_sources_id_fk": {
+          "name": "delivery_log_source_id_notification_sources_id_fk",
+          "tableFrom": "delivery_log",
+          "tableTo": "notification_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_members": {
+      "name": "household_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hm_household_id_idx": {
+          "name": "hm_household_id_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "hm_user_id_idx": {
+          "name": "hm_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_members_household_id_households_id_fk": {
+          "name": "household_members_household_id_households_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_members_user_id_auth_user_id_fk": {
+          "name": "household_members_user_id_auth_user_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "auth_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_members_role_id_household_roles_id_fk": {
+          "name": "household_members_role_id_household_roles_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "household_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_roles": {
+      "name": "household_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_roles_name_unique": {
+          "name": "household_roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Warsaw'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_sources": {
+      "name": "notification_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "alert_before_hours": {
+          "name": "alert_before_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ns_household_id_idx": {
+          "name": "ns_household_id_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_sources_household_id_households_id_fk": {
+          "name": "notification_sources_household_id_households_id_fk",
+          "tableFrom": "notification_sources",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/data-ops/src/drizzle/migrations/dev/meta/_journal.json
+++ b/packages/data-ops/src/drizzle/migrations/dev/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1775931431087,
       "tag": "0016_classy_prism",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1776063268980,
+      "tag": "0017_exotic_shaman",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/data-ops/src/drizzle/schema.ts
+++ b/packages/data-ops/src/drizzle/schema.ts
@@ -88,6 +88,7 @@ export const notificationSources = pgTable(
 		name: text("name").notNull(),
 		type: text("type").notNull(),
 		config: jsonb("config").notNull().default({}),
+		alertBeforeHours: integer("alert_before_hours"),
 		topicId: integer("topic_id"),
 		enabled: boolean("enabled").default(true).notNull(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/packages/data-ops/src/queries/delivery.ts
+++ b/packages/data-ops/src/queries/delivery.ts
@@ -1,6 +1,6 @@
 import { getDb } from "@/database/setup";
 import { deliveryLog, deliveryFailures } from "@/drizzle/schema";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, inArray, sql } from "drizzle-orm";
 import type { InsertDeliveryLog, InsertDeliveryFailure } from "@/zod-schema/delivery";
 
 export async function insertDeliveryLog(input: InsertDeliveryLog) {
@@ -16,6 +16,40 @@ export async function getDeliveryLogs(sourceId: number) {
 		.from(deliveryLog)
 		.where(eq(deliveryLog.sourceId, sourceId))
 		.orderBy(desc(deliveryLog.createdAt));
+}
+
+export async function getLatestDeliveryBySourceIds(
+	sourceIds: number[],
+): Promise<Map<number, { status: string; error: string | null; createdAt: Date }>> {
+	if (sourceIds.length === 0) return new Map();
+
+	const db = getDb();
+
+	const latestPerSource = db
+		.select({
+			sourceId: deliveryLog.sourceId,
+			maxId: sql<number>`max(${deliveryLog.id})`.as("max_id"),
+		})
+		.from(deliveryLog)
+		.where(inArray(deliveryLog.sourceId, sourceIds))
+		.groupBy(deliveryLog.sourceId)
+		.as("latest");
+
+	const rows = await db
+		.select({
+			sourceId: deliveryLog.sourceId,
+			status: deliveryLog.status,
+			error: deliveryLog.error,
+			createdAt: deliveryLog.createdAt,
+		})
+		.from(deliveryLog)
+		.innerJoin(latestPerSource, sql`${deliveryLog.id} = ${latestPerSource.maxId}`);
+
+	const map = new Map<number, { status: string; error: string | null; createdAt: Date }>();
+	for (const row of rows) {
+		map.set(row.sourceId, { status: row.status, error: row.error, createdAt: row.createdAt });
+	}
+	return map;
 }
 
 export async function insertDeliveryFailure(input: InsertDeliveryFailure) {

--- a/packages/data-ops/src/zod-schema/notification-source.ts
+++ b/packages/data-ops/src/zod-schema/notification-source.ts
@@ -8,6 +8,7 @@ export const NotificationSourceResponse = z.object({
 	name: z.string(),
 	type: z.string(),
 	config: JsonConfig,
+	alertBeforeHours: z.number().nullable(),
 	topicId: z.number().nullable(),
 	enabled: z.boolean(),
 	createdAt: z.date(),
@@ -21,6 +22,7 @@ export const CreateNotificationSourceInput = z.object({
 	name: z.string(),
 	type: z.string(),
 	config: JsonConfig.default({}),
+	alertBeforeHours: z.number().int().positive().optional(),
 	enabled: z.boolean().optional(),
 });
 
@@ -30,6 +32,7 @@ export const UpdateNotificationSourceInput = z.object({
 	name: z.string().optional(),
 	type: z.string().optional(),
 	config: JsonConfig.optional(),
+	alertBeforeHours: z.number().int().positive().optional(),
 	topicId: z.number().optional(),
 	enabled: z.boolean().optional(),
 });

--- a/packages/data-ops/src/zod-schema/source-form-schema.test.ts
+++ b/packages/data-ops/src/zod-schema/source-form-schema.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-	SourceFormInput,
-	getAlertBeforeHoursDefault,
-	SOURCE_TYPES,
-} from "./source-form-schema";
+import { SourceFormInput, getAlertBeforeHoursDefault, SOURCE_TYPES } from "./source-form-schema";
 
 describe("SourceFormInput zod schema", () => {
 	it("accepts valid waste_collection input", () => {
@@ -110,11 +106,7 @@ describe("getAlertBeforeHoursDefault", () => {
 
 describe("SOURCE_TYPES", () => {
 	it("contains waste_collection and birthday", () => {
-		expect(SOURCE_TYPES).toContainEqual(
-			expect.objectContaining({ value: "waste_collection" }),
-		);
-		expect(SOURCE_TYPES).toContainEqual(
-			expect.objectContaining({ value: "birthday" }),
-		);
+		expect(SOURCE_TYPES).toContainEqual(expect.objectContaining({ value: "waste_collection" }));
+		expect(SOURCE_TYPES).toContainEqual(expect.objectContaining({ value: "birthday" }));
 	});
 });

--- a/packages/data-ops/src/zod-schema/source-form-schema.test.ts
+++ b/packages/data-ops/src/zod-schema/source-form-schema.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+	SourceFormInput,
+	getAlertBeforeHoursDefault,
+	SOURCE_TYPES,
+} from "./source-form-schema";
+
+describe("SourceFormInput zod schema", () => {
+	it("accepts valid waste_collection input", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Wywóz śmieci",
+			type: "waste_collection",
+			config: {
+				address: "ul. Kwiatowa 5",
+				schedule: [{ type: "szkło", dates: ["2026-04-15"] }],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts valid birthday input", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Urodziny rodziny",
+			type: "birthday",
+			config: {
+				birthdays: [{ name: "Mama", date: "03-15" }],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects waste_collection with birthday config", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Test",
+			type: "waste_collection",
+			config: {
+				birthdays: [{ name: "Mama", date: "03-15" }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects birthday with waste_collection config", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Test",
+			type: "birthday",
+			config: {
+				address: "ul. Kwiatowa 5",
+				schedule: [{ type: "szkło", dates: ["2026-04-15"] }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts custom alertBeforeHours", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Test",
+			type: "waste_collection",
+			config: {
+				address: "ul. Kwiatowa 5",
+				schedule: [{ type: "szkło", dates: ["2026-04-15"] }],
+			},
+			alertBeforeHours: 12,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.alertBeforeHours).toBe(12);
+		}
+	});
+
+	it("rejects negative alertBeforeHours", () => {
+		const result = SourceFormInput.safeParse({
+			name: "Test",
+			type: "waste_collection",
+			config: {
+				address: "ul. Kwiatowa 5",
+				schedule: [{ type: "szkło", dates: ["2026-04-15"] }],
+			},
+			alertBeforeHours: -1,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects empty name", () => {
+		const result = SourceFormInput.safeParse({
+			name: "",
+			type: "waste_collection",
+			config: {
+				address: "ul. Kwiatowa 5",
+				schedule: [{ type: "szkło", dates: ["2026-04-15"] }],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("getAlertBeforeHoursDefault", () => {
+	it("returns 18 for waste_collection", () => {
+		expect(getAlertBeforeHoursDefault("waste_collection")).toBe(18);
+	});
+
+	it("returns 24 for birthday", () => {
+		expect(getAlertBeforeHoursDefault("birthday")).toBe(24);
+	});
+
+	it("returns 24 for unknown type", () => {
+		expect(getAlertBeforeHoursDefault("unknown")).toBe(24);
+	});
+});
+
+describe("SOURCE_TYPES", () => {
+	it("contains waste_collection and birthday", () => {
+		expect(SOURCE_TYPES).toContainEqual(
+			expect.objectContaining({ value: "waste_collection" }),
+		);
+		expect(SOURCE_TYPES).toContainEqual(
+			expect.objectContaining({ value: "birthday" }),
+		);
+	});
+});

--- a/packages/data-ops/src/zod-schema/source-form-schema.ts
+++ b/packages/data-ops/src/zod-schema/source-form-schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { WasteCollectionConfig } from "./waste-collection-config";
+import { BirthdayConfig } from "./birthday-config";
+
+export const SOURCE_TYPES = [
+	{ value: "waste_collection" as const, label: "Wywóz śmieci", icon: "🗑" },
+	{ value: "birthday" as const, label: "Urodziny", icon: "🎂" },
+] as const;
+
+export type SourceType = (typeof SOURCE_TYPES)[number]["value"];
+
+const ALERT_DEFAULTS: Record<string, number> = {
+	waste_collection: 18,
+	birthday: 24,
+};
+
+export function getAlertBeforeHoursDefault(type: string): number {
+	return ALERT_DEFAULTS[type] ?? 24;
+}
+
+const WasteCollectionForm = z.object({
+	name: z.string().min(1),
+	type: z.literal("waste_collection"),
+	config: WasteCollectionConfig,
+	alertBeforeHours: z.number().int().positive().optional(),
+});
+
+const BirthdayForm = z.object({
+	name: z.string().min(1),
+	type: z.literal("birthday"),
+	config: BirthdayConfig,
+	alertBeforeHours: z.number().int().positive().optional(),
+});
+
+export const SourceFormInput = z.discriminatedUnion("type", [
+	WasteCollectionForm,
+	BirthdayForm,
+]);
+
+export type SourceFormInput = z.infer<typeof SourceFormInput>;

--- a/packages/data-ops/src/zod-schema/source-form-schema.ts
+++ b/packages/data-ops/src/zod-schema/source-form-schema.ts
@@ -32,9 +32,6 @@ const BirthdayForm = z.object({
 	alertBeforeHours: z.number().int().positive().optional(),
 });
 
-export const SourceFormInput = z.discriminatedUnion("type", [
-	WasteCollectionForm,
-	BirthdayForm,
-]);
+export const SourceFormInput = z.discriminatedUnion("type", [WasteCollectionForm, BirthdayForm]);
 
 export type SourceFormInput = z.infer<typeof SourceFormInput>;

--- a/packages/data-ops/tests/integration/delivery.roundtrip.test.ts
+++ b/packages/data-ops/tests/integration/delivery.roundtrip.test.ts
@@ -9,6 +9,7 @@ import { initDatabase, resetDatabase } from "@/database/setup";
 import {
 	insertDeliveryLog,
 	getDeliveryLogs,
+	getLatestDeliveryBySourceIds,
 	insertDeliveryFailure,
 	getDeliveryFailures,
 } from "@/queries/delivery";
@@ -95,6 +96,23 @@ describe("delivery log + failures CRUD (data-ops ↔ test-harness)", () => {
 		expect(row.error).toBe("HTTP 429: rate limited");
 		expect(row.retryCount).toBe(3);
 		expect(row.payload).toEqual({ recipient: "-100123", body: "test" });
+	});
+
+	it("getLatestDeliveryBySourceIds returns most recent log per source", async () => {
+		await insertDeliveryLog({ sourceId, channel: "telegram", status: "success", retryCount: 0 });
+		await insertDeliveryLog({ sourceId, channel: "telegram", status: "failure", error: "err", retryCount: 1 });
+
+		const map = await getLatestDeliveryBySourceIds([sourceId]);
+		expect(map.has(sourceId)).toBe(true);
+
+		const latest = map.get(sourceId)!;
+		expect(latest.status).toBe("failure");
+		expect(latest.error).toBe("err");
+	});
+
+	it("getLatestDeliveryBySourceIds returns empty map for no sources", async () => {
+		const map = await getLatestDeliveryBySourceIds([]);
+		expect(map.size).toBe(0);
 	});
 
 	it("getDeliveryFailures returns failures for a source", async () => {

--- a/packages/data-ops/tests/integration/delivery.roundtrip.test.ts
+++ b/packages/data-ops/tests/integration/delivery.roundtrip.test.ts
@@ -100,7 +100,13 @@ describe("delivery log + failures CRUD (data-ops ↔ test-harness)", () => {
 
 	it("getLatestDeliveryBySourceIds returns most recent log per source", async () => {
 		await insertDeliveryLog({ sourceId, channel: "telegram", status: "success", retryCount: 0 });
-		await insertDeliveryLog({ sourceId, channel: "telegram", status: "failure", error: "err", retryCount: 1 });
+		await insertDeliveryLog({
+			sourceId,
+			channel: "telegram",
+			status: "failure",
+			error: "err",
+			retryCount: 1,
+		});
 
 		const map = await getLatestDeliveryBySourceIds([sourceId]);
 		expect(map.has(sourceId)).toBe(true);


### PR DESCRIPTION
## Summary
- Source list view with type icons, status badges, last delivery info
- Create/edit forms with dynamic config fields per source type (waste_collection, birthday)
- Delete confirmation dialog with cascade cleanup
- Server functions with Zod validation (discriminated union per type)
- `alertBeforeHours` column added to `notification_sources` schema
- Batch `getLatestDeliveryBySourceIds` query for list view
- HTTP endpoints in data-service for source lifecycle
- i18n translations (pl/en) for all new UI strings
- Nav link to Sources in dashboard

## Test plan
- [x] 106 data-ops tests passing (including 13 new)
- [x] 69 data-service tests passing (including 4 new)
- [x] TypeScript clean in user-application
- [ ] Manual: visit `/app/sources` — empty state renders
- [ ] Manual: create waste_collection source — form validates, redirects to list
- [ ] Manual: create birthday source — dynamic fields switch correctly
- [ ] Manual: edit source — form pre-filled with current config
- [ ] Manual: delete source — confirmation dialog, removed from list
- [ ] Deploy to staging and verify

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)